### PR TITLE
Simple extension from "double gamma" to Lagrangian multi-material "Coefficient *gamma".

### DIFF
--- a/laghos.cpp
+++ b/laghos.cpp
@@ -277,19 +277,22 @@ int main(int argc, char *argv[])
    }
    e_gf.ProjectGridFunction(l2_e);
 
+   // Material distribution over the Lagrangian mesh.
+   Coefficient *material_pcf = new FunctionCoefficient(hydrodynamics::gamma);
+
    // Additional details, depending on the problem.
-   int source = 0; bool visc; double gamma;
+   int source = 0; bool visc;
    switch (problem)
    {
       case 0: if (pmesh->Dimension() == 2) { source = 1; }
-         visc = false; gamma = 5.0 / 3.0; break;
-      case 1: visc = true; gamma = 1.4; break;
+         visc = false; break;
+      case 1: visc = true; break;
       default: MFEM_ABORT("Wrong problem specification!");
    }
 
    LagrangianHydroOperator oper(S.Size(), H1FESpace, L2FESpace,
-                                ess_tdofs, rho, source, cfl, gamma,
-                                visc, p_assembly);
+                                ess_tdofs, rho, source, cfl, material_pcf, 
+								visc, p_assembly);
 
    socketstream vis_rho, vis_v, vis_e;
    char vishost[] = "localhost";
@@ -456,6 +459,7 @@ int main(int argc, char *argv[])
    // Free the used memory.
    delete ode_solver;
    delete pmesh;
+   delete material_pcf;
 
    return 0;
 }
@@ -473,6 +477,16 @@ double rho0(const Vector &x)
       case 0: return 1.0;
       case 1: return 1.0;
       default: MFEM_ABORT("Bad number given for problem id!"); return 0.0;
+   }
+}
+
+double gamma(const Vector &x)
+{
+   switch (problem)
+   {
+      case 0: return 5./3.;
+      case 1: return 1.4;
+	  default: MFEM_ABORT("Bad number given for problem id!"); return 0.0;
    }
 }
 

--- a/laghos.cpp
+++ b/laghos.cpp
@@ -277,7 +277,7 @@ int main(int argc, char *argv[])
    }
    e_gf.ProjectGridFunction(l2_e);
 
-   // Material distribution over the Lagrangian mesh.
+   // Space-dependent ideal gas coefficient over the Lagrangian mesh.
    Coefficient *material_pcf = new FunctionCoefficient(hydrodynamics::gamma);
 
    // Additional details, depending on the problem.
@@ -291,8 +291,8 @@ int main(int argc, char *argv[])
    }
 
    LagrangianHydroOperator oper(S.Size(), H1FESpace, L2FESpace,
-                                ess_tdofs, rho, source, cfl, material_pcf, 
-								visc, p_assembly);
+                                ess_tdofs, rho, source, cfl, material_pcf,
+                                visc, p_assembly);
 
    socketstream vis_rho, vis_v, vis_e;
    char vishost[] = "localhost";

--- a/laghos_solver.cpp
+++ b/laghos_solver.cpp
@@ -499,11 +499,11 @@ void LagrangianHydroOperator::UpdateQuadratureData(const Vector &S) const
          ++z_id;
       }
    }
-   delete gamma_b;
-   delete rho_b;
-   delete e_b;
-   delete p_b;
-   delete cs_b;
+   delete [] gamma_b;
+   delete [] rho_b;
+   delete [] e_b;
+   delete [] p_b;
+   delete [] cs_b;
    quad_data_is_current = true;
 }
 

--- a/laghos_solver.cpp
+++ b/laghos_solver.cpp
@@ -86,8 +86,8 @@ LagrangianHydroOperator::LagrangianHydroOperator(int size,
                                                  Array<int> &essential_tdofs,
                                                  ParGridFunction &rho0,
                                                  int source_type_, double cfl_, 
-												                         Coefficient *material_,
-												                         bool visc, bool pa)
+                                                 Coefficient *material_,
+                                                 bool visc, bool pa)
    : TimeDependentOperator(size),
      H1FESpace(h1_fes), L2FESpace(l2_fes),
      H1compFESpace(h1_fes.GetParMesh(), h1_fes.FEColl(), 1),
@@ -96,8 +96,8 @@ LagrangianHydroOperator::LagrangianHydroOperator(int size,
      nzones(h1_fes.GetMesh()->GetNE()),
      l2dofs_cnt(l2_fes.GetFE(0)->GetDof()),
      h1dofs_cnt(h1_fes.GetFE(0)->GetDof()),
-     source_type(source_type_), cfl(cfl_), 
-	 material_pcf(material_),
+     source_type(source_type_), cfl(cfl_),
+     material_pcf(material_),
      use_viscosity(visc), p_assembly(pa),
      Mv(&h1_fes), Me_inv(l2dofs_cnt, l2dofs_cnt, nzones),
      integ_rule(IntRules.Get(h1_fes.GetMesh()->GetElementBaseGeometry(),
@@ -445,12 +445,9 @@ void LagrangianHydroOperator::UpdateQuadratureData(const Vector &S) const
             MFEM_VERIFY(detJ > 0.0, "Bad Jacobian determinant: " << detJ);
 
             const int idx = z * nqp + q;
-			if (material_pcf==NULL) { gamma_b[idx] = 5./3.; } // Ideal gas.
-			else
-			{ 
-			   gamma_b[idx] = material_pcf->Eval(*T, ip);
-			}
-			rho_b[idx] = quad_data.rho0DetJ0w(z_id*nqp + q) / detJ / ip.weight;
+            if (material_pcf == NULL) { gamma_b[idx] = 5./3.; } // Ideal gas.
+            else { gamma_b[idx] = material_pcf->Eval(*T, ip); }
+            rho_b[idx] = quad_data.rho0DetJ0w(z_id*nqp + q) / detJ / ip.weight;
             e_b[idx]   = max(0.0, e_vals(q));
          }
          ++z_id;

--- a/laghos_solver.hpp
+++ b/laghos_solver.hpp
@@ -115,7 +115,7 @@ public:
                            ParFiniteElementSpace &l2_fes,
                            Array<int> &essential_tdofs, ParGridFunction &rho0,
                            int source_type_, double cfl_, 
-						   Coefficient *material_, bool visc, bool pa);
+                           Coefficient *material_, bool visc, bool pa);
 
    // Solve for dx_dt, dv_dt and de_dt.
    virtual void Mult(const Vector &S, Vector &dS_dt) const;

--- a/laghos_solver.hpp
+++ b/laghos_solver.hpp
@@ -50,6 +50,7 @@ namespace hydrodynamics
 double rho0(const Vector &);
 void v0(const Vector &, Vector &);
 double e0(const Vector &);
+double gamma(const Vector &);
 
 // Given a solutions state (x, v, e), this class performs all necessary
 // computations to evaluate the new slopes (dx_dt, dv_dt, de_dt).
@@ -63,8 +64,9 @@ protected:
    Array<int> &ess_tdofs;
 
    const int dim, nzones, l2dofs_cnt, h1dofs_cnt, source_type;
-   const double cfl, gamma;
+   const double cfl;
    const bool use_viscosity, p_assembly;
+   Coefficient *material_pcf;
 
    // Velocity mass matrix and local inverses of the energy mass matrices. These
    // are constant in time, due to the pointwise mass conservation property.
@@ -95,14 +97,14 @@ protected:
    // Linear solver for energy.
    CGSolver locCG;
 
-   void ComputeMaterialProperties(int nvalues,
+   void ComputeMaterialProperties(int nvalues, const double gamma[],
                                   const double rho[], const double e[],
                                   double p[], double cs[]) const
    {
       for (int v = 0; v < nvalues; v++)
       {
-         p[v]  = (gamma - 1.0) * rho[v] * e[v];
-         cs[v] = sqrt(gamma * (gamma-1.0) * e[v]);
+         p[v]  = (gamma[v] - 1.0) * rho[v] * e[v];
+         cs[v] = sqrt(gamma[v] * (gamma[v]-1.0) * e[v]);
       }
    }
 
@@ -112,8 +114,8 @@ public:
    LagrangianHydroOperator(int size, ParFiniteElementSpace &h1_fes,
                            ParFiniteElementSpace &l2_fes,
                            Array<int> &essential_tdofs, ParGridFunction &rho0,
-                           int source_type_, double cfl_,
-                           double gamma_, bool visc, bool pa);
+                           int source_type_, double cfl_, 
+						   Coefficient *material_, bool visc, bool pa);
 
    // Solve for dx_dt, dv_dt and de_dt.
    virtual void Mult(const Vector &S, Vector &dS_dt) const;


### PR DESCRIPTION
Added extension from one scalar value of gamma to a gamma/material coefficient operating on Lagrangian mesh. This coefficient is called within UpdateQuadratureData for every batch point and the material information is passed to ComputeMaterialProperties as gamma_b.