### PR TITLE
General blast position

### DIFF
--- a/amr/laghos.cpp
+++ b/amr/laghos.cpp
@@ -109,9 +109,8 @@ int main(int argc, char *argv[])
    double deref_threshold = 0.75;
    const int nc_limit = 1;
    const double blast_energy = 0.25;
-   //const double blast_position[] = {0.0, 0.0, 0.0};
-   const double blast_position[] = {1.0, 0.5, 0.5};
-   const double blast_amr_size = 0.2; //1e-10;
+   const double blast_position[] = {0.0, 0.0, 0.0};
+   const double blast_amr_size = 1e-10;
 
    OptionsParser args(argc, argv);
    args.AddOption(&mesh_file, "-m", "--mesh",

--- a/amr/laghos.cpp
+++ b/amr/laghos.cpp
@@ -68,7 +68,8 @@ void AMRUpdate(BlockVector &S, BlockVector &S_tmp,
 void GetZeroBCDofs(ParMesh *pmesh, ParFiniteElementSpace *pspace,
                    int bdr_attr_max, Array<int> &ess_tdofs);
 
-int FindElementWithVertex(const Mesh* mesh, const Vertex &vert);
+void FindElementsWithVertex(const Mesh* mesh, const Vertex &vert,
+                            const double size, Array<int> &elements);
 
 void GetPerElementMinMax(const GridFunction &gf,
                          Vector &elem_min, Vector &elem_max,
@@ -107,6 +108,10 @@ int main(int argc, char *argv[])
    double ref_threshold = 2e-4;
    double deref_threshold = 0.75;
    const int nc_limit = 1;
+   const double blast_energy = 0.25;
+   //const double blast_position[] = {0.0, 0.0, 0.0};
+   const double blast_position[] = {1.0, 0.5, 0.5};
+   const double blast_amr_size = 0.2; //1e-10;
 
    OptionsParser args(argc, argv);
    args.AddOption(&mesh_file, "-m", "--mesh",
@@ -198,7 +203,9 @@ int main(int argc, char *argv[])
       mesh->EnsureNCMesh();
       for (int lev = 0; lev < rs_levels; lev++)
       {
-         mesh->RefineAtVertex(Vertex(0, 0, 0));
+         mesh->RefineAtVertex(Vertex(blast_position[0], blast_position[1],
+                                     blast_position[2]),
+                              blast_amr_size);
       }
    }
 
@@ -409,7 +416,8 @@ int main(int argc, char *argv[])
       if (problem == 1)
       {
          // For the Sedov test, we use a delta function at the origin.
-         DeltaCoefficient e_coeff(0, 0, 0.25);
+         DeltaCoefficient e_coeff(blast_position[0], blast_position[1],
+                                  blast_position[2], blast_energy);
          l2_e.ProjectCoefficient(e_coeff);
       }
       else
@@ -664,9 +672,17 @@ int main(int argc, char *argv[])
             MPI_Allreduce(&loc_threshold, &threshold, 1, MPI_DOUBLE, MPI_MAX,
                           pmesh->GetComm());
 
-            // make sure the blast corner is never derefined
-            int index = FindElementWithVertex(pmesh, Vertex(0, 0, 0));
-            if (index >= 0) { rho_max(index) = 1e10; }
+            // make sure the blast point is never derefined
+            Array<int> elements;
+			FindElementsWithVertex(pmesh, Vertex(blast_position[0],
+                                                 blast_position[1],
+                                                 blast_position[2]),
+                                   blast_amr_size, elements);
+			for (int i = 0; i < elements.Size(); i++)
+            {
+               int index = elements[i];
+			   if (index >= 0) { rho_max(index) = 1e10; }
+            }
 
             // also, only derefine where the mesh is in motion, i.e. after the shock
             for (int i = 0; i < pmesh->GetNE(); i++)
@@ -780,11 +796,10 @@ void AMRUpdate(BlockVector &S, BlockVector &S_tmp,
    S_tmp.Update(true_offset, true);
 }
 
-
-int FindElementWithVertex(const Mesh* mesh, const Vertex &vert)
+void FindElementsWithVertex(const Mesh* mesh, const Vertex &vert,
+                            const double size, Array<int> &elements)
 {
    Array<int> v;
-   const double eps = 1e-10;
 
    for (int i = 0; i < mesh->GetNE(); i++)
    {
@@ -797,10 +812,9 @@ int FindElementWithVertex(const Mesh* mesh, const Vertex &vert)
             double d = vert(l) - mesh->GetVertex(v[j])[l];
             dist += d*d;
          }
-         if (dist <= eps*eps) { return i; }
+         if (dist <= size*size) { elements.Append(i); break; }
       }
    }
-   return -1;
 }
 
 void Pow(Vector &vec, double p)

--- a/laghos.cpp
+++ b/laghos.cpp
@@ -104,8 +104,7 @@ int main(int argc, char *argv[])
    const char *basename = "results/Laghos";
    int partition_type = 111;
    double blast_energy = 0.25;
-   //double blast_position[] = {0.0, 0.0, 0.0};
-   double blast_position[] = {1.0, 0.5, 0.5};
+   double blast_position[] = {0.0, 0.0, 0.0};
 
    OptionsParser args(argc, argv);
    args.AddOption(&mesh_file, "-m", "--mesh",

--- a/laghos.cpp
+++ b/laghos.cpp
@@ -103,6 +103,9 @@ int main(int argc, char *argv[])
    bool gfprint = false;
    const char *basename = "results/Laghos";
    int partition_type = 111;
+   double blast_energy = 0.25;
+   //double blast_position[] = {0.0, 0.0, 0.0};
+   double blast_position[] = {1.0, 0.5, 0.5};
 
    OptionsParser args(argc, argv);
    args.AddOption(&mesh_file, "-m", "--mesh",
@@ -387,7 +390,8 @@ int main(int argc, char *argv[])
    if (problem == 1)
    {
       // For the Sedov test, we use a delta function at the origin.
-      DeltaCoefficient e_coeff(0, 0, 0.25);
+      DeltaCoefficient e_coeff(blast_position[0], blast_position[1],
+                               blast_position[2], blast_energy);
       l2_e.ProjectCoefficient(e_coeff);
    }
    else

--- a/laghos_solver.cpp
+++ b/laghos_solver.cpp
@@ -58,10 +58,13 @@ void VisualizeField(socketstream &sock, const char *vishost, int visport,
 
       if (myid == 0 && newly_opened)
       {
+         const char* keys = (gf.FESpace()->GetMesh()->Dimension() == 2)
+                            ? "mAcRjlPPPPPPPP" : "maaAcl";
+
          sock << "window_title '" << title << "'\n"
               << "window_geometry "
               << x << " " << y << " " << w << " " << h << "\n"
-              << "keys maaAcl";
+              << "keys " << keys;
          if ( vec ) { sock << "vvv"; }
          sock << endl;
       }


### PR DESCRIPTION
A general positioning of the blast in Sedov provides a very simple but potentially useful extension.
The aim of this is to apply free-surface BC, while placing the blast source in the middle of an edge of the computational domain. It also applies to AMR @jakubcerveny .