### PR TITLE
only include header if using openmpi

### DIFF
--- a/cuda/cuda/config/config.cpp
+++ b/cuda/cuda/config/config.cpp
@@ -14,7 +14,9 @@
 // software, applications, hardware, advanced system engineering and early
 // testbed platforms, in support of the nation's exascale computing imperative.
 #include "../cuda.hpp"
+#if defined(OPEN_MPI) && OPEN_MPI
 #include <mpi-ext.h>
+#endif
 #include <unistd.h>
 
 namespace mfem


### PR DESCRIPTION
This PR allows compilation with MPI implementations that are not OpenMPI.