### PR TITLE
build: permit PREFIX, MFEM_DIR overrides

### DIFF
--- a/makefile
+++ b/makefile
@@ -47,11 +47,11 @@ make style
 endef
 
 # Default installation location
-PREFIX = ./bin
+PREFIX ?= ./bin
 INSTALL = /usr/bin/install
 
 # Use the MFEM build directory
-MFEM_DIR = ../mfem
+MFEM_DIR ?= ../mfem
 CONFIG_MK = $(MFEM_DIR)/config/config.mk
 TEST_MK = $(MFEM_DIR)/config/test.mk
 # Use the MFEM install directory


### PR DESCRIPTION
This commit enables users to override values of `PREFIX` and `MFEM_DIR` at
the command line. The motivation for this change is to enable building
Laghos with different MFEM builds by defining variables at the command
line or in scripts. This feature also avoids polluting the repository with
trivial changes to paths in the project makefile when testing
different MFEM configurations, and permits building MFEM out-of-tree.