### PR TITLE
change code to work with regression test and new libROM master

### DIFF
--- a/COMPILE.md
+++ b/COMPILE.md
@@ -13,77 +13,18 @@ This document explains how to compile Laghos/libROM together for several differe
    * brew install hdf5
 2. Choose a base directory, call it \<PATH\>.
 3. From \<PATH\>, clone the rom-dev branch of Laghos.
-4. From \<PATH\>, follow the instructions from the master branch of Laghos to build HYPRE, Metis, and MFEM, but don’t compile Laghos yet. The instructions in the rom-dev branch are out-of-date and will lead to errors as the instructions say to use an older MFEM version that won’t compile with rom-dev.
-5. Before building MFEM by running (make parallel -j), you will need to run the following commands from the \<PATH\>/mfem/config directory:
+4. From \<PATH]>, download and build HYPRE and Metis following the instructions from the README.md of the master branch of Laghos.
+5. From \<PATH\>, download MFEM and run the following commands from \<PATH\>/mfem/config:
    * cp defaults.mk user.mk
-   * Alter HYPRE_DIR to user.mk to point to your HYPRE folder. Mine looks like the following: 
-   
+   * Alter HYPRE_DIR to user.mk to point to your HYPRE folder. Mine looks like the following:
+
       HYPRE_DIR = @MFEM_DIR@/../hypre-2.11.2/src/hypre
-      
-6. From \<PATH\>, clone the master branch of the libROM repository. 
-7. Alter the CMakeLists.txt by making the libROM library shared so you can avoid having to relink its dependencies when compiling Laghos. If you want to relink the dependencies in the Laghos makefile instead of making the library shared, you can reinclude (MPI, HDF5, Fortran, etc.) in the Laghos makefile. You will also need to include MPI_Fortran so Scalapack can be linked correctly. Here is a git diff of the changes I made from the master version of CMakeLists.txt:
-   
-         diff --git a/CMakeLists.txt b/CMakeLists.txt
-         index b81fae5..4f19ce6 100644
-         --- a/CMakeLists.txt
-         +++ b/CMakeLists.txt
-         @@ -144,7 +144,7 @@ list(APPEND source_files
-            scalapack_c_wrapper.c
-            scalapack_f_wrapper.f90)
- 
-         -add_library(ROM ${source_files})
-         +add_library(ROM SHARED ${source_files} )
- 
-         # List minimum version requirements for dependencies where possible to make
-         # packaging easier later.
-         @@ -194,7 +194,7 @@ find_package(GTest 1.6.0)
-         # but is done here to ease a potential rollback to CMake 2.8 or CMake 3.0
-         target_link_libraries(ROM
-         -  PUBLIC ${MPI_C_LINK_FLAGS} ${MPI_C_LIBRARIES} MPI::MPI_C ${HDF5_LIBRARIES}
-         +  PUBLIC ${MPI_C_LINK_FLAGS} ${MPI_C_LIBRARIES} MPI::MPI_C ${MPI_Fortran_LINK_FLAGS} ${MPI_Fortran_LIBRARIES} MPI::MPI_Fortran ${HDF5_LIBRARIES}
-            ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES}
-            PRIVATE ${ZLIB_LIBRARIES} ZLIB::ZLIB)
- 
-         @@ -218,7 +218,7 @@ foreach(name IN LISTS regression_test_names)
-            add_executable(${name} ${name}.C)
- 
-            target_link_libraries(${name}
-         -    PRIVATE ROM ${MPI_C_LINK_FLAGS} ${MPI_C_LIBRARIES} MPI::MPI_C)
-         +    PRIVATE ROM ${MPI_C_LINK_FLAGS} ${MPI_C_LIBRARIES} MPI::MPI_C ${MPI_Fortran_LINK_FLAGS} ${MPI_Fortran_LIBRARIES} MPI::MPI_Fortran)
-            target_include_directories(${name}
-              PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-              ${MPI_C_INCLUDE_DIRS})
-         @@ -234,7 +234,7 @@ if(GTEST_FOUND)
-            foreach(stem IN LISTS unit_test_stems)
-              add_executable(test_${stem} tests/test_${stem}.C)
-              target_link_libraries(test_${stem} PRIVATE ROM
-         -      ${MPI_C_LINK_FLAGS} ${MPI_C_LIBRARIES} MPI::MPI_C GTest::GTest)
-         +      ${MPI_C_LINK_FLAGS} ${MPI_C_LIBRARIES} MPI::MPI_C GTest::GTest ${MPI_Fortran_LIBRARIES})
-              target_include_directories(test_${stem}
-                PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-                ${MPI_C_INCLUDE_DIRS})
+6. Build MFEM following the instructions from the README.md of the master branch of Laghos.
+7. From \<PATH\>, clone the master branch of the libROM repository.
 8. Run the following commands from \<PATH\>/libROM/build:
    * cmake ../
    * make
-9. In \<PATH\>/Laghos, create a user.mk file that includes your ScaLAPACK path and flags. Here is an example:
-   * SCALAPACKLIB = -Wl,-rpath,/usr/local/opt/scalapack/lib
-   * SCALAPACK_FLAGS = -lscalapack -lpthread -lm -ldl
-10. We need to include the correct source files and libraries in the Laghos executable in the makefile for it to build correctly. Here is the git diff of the changes I made from the rom-dev branch version of the makefile:
-   
-         --- a/makefile
-         +++ b/makefile
-         @@ -122,8 +122,10 @@ include user.mk
-         .c.o:
-            cd $(<D); $(Ccc) -c $(<F)
-      
-         -laghos: override MFEM_DIR = $(MFEM_DIR1)
-         -include user2.mk
-         +laghos: $(OBJECT_FILES) $(CONFIG_MK) $(MFEM_LIB_FILE)
-         +      $(CCC) -o laghos $(OBJECT_FILES) $(LIBS) -L../libROM/build -lROM -Wl,-rpath,../libROM/build
-         +      $(SCALAPACKLIB) $(SCALAPACK_FLAGS)
-         +#include user2.mk
-         
-11. From \<PATH\>/Laghos, run the following command:
+9. From \<PATH\>/Laghos, create a user.mk file that includes your ScaLAPACK path and flags. Here is an example:
+   * SCALAPACK_FLAGS=-L/usr/local/opt/scalapack -lscalapack       
+10. From \<PATH\>/Laghos, run the following command:
       * make
-   
-Now Laghos and libROM have compiled together and we are finished.

--- a/COMPILE.md
+++ b/COMPILE.md
@@ -13,7 +13,7 @@ This document explains how to compile Laghos/libROM together for several differe
    * brew install hdf5
 2. Choose a base directory, call it \<PATH\>.
 3. From \<PATH\>, clone the rom-dev branch of Laghos.
-4. From \<PATH]>, download and build HYPRE and Metis following the instructions from the README.md of the master branch of Laghos.
+4. From \<PATH\>, download and build HYPRE and Metis following the instructions from the README.md of the master branch of Laghos.
 5. From \<PATH\>, download MFEM and run the following commands from \<PATH\>/mfem/config:
    * cp defaults.mk user.mk
    * Alter HYPRE_DIR to user.mk to point to your HYPRE folder. Mine looks like the following:

--- a/laghos.cpp
+++ b/laghos.cpp
@@ -911,7 +911,7 @@ int main(int argc, char *argv[])
                 // TODO: think about how to reuse "gfprint" option
                 std::string filename = std::string("run/ROMsol/romS_")+std::to_string(ti);
                 std::ofstream outfile_romS(filename.c_str());
-                romS.Print(outfile_romS, 16);
+                romS.Print(outfile_romS, 1);
                 outfile_romS.close();
 
                 if (!rom_hyperreduce)
@@ -1211,15 +1211,15 @@ int main(int argc, char *argv[])
     }
 
     std::ofstream outfile_e("run/e_gf");
-    e_gf.Print(outfile_e, 16);
+    e_gf.Print(outfile_e, 1);
     outfile_e.close();
 
     std::ofstream outfile_v("run/v_gf");
-    v_gf.Print(outfile_v, 16);
+    v_gf.Print(outfile_v, 1);
     outfile_v.close();
 
     std::ofstream outfile_x("run/x_gf");
-    x_gf.Print(outfile_x, 16);
+    x_gf.Print(outfile_x, 1);
     outfile_x.close();
 
     // Print the error.

--- a/makefile
+++ b/makefile
@@ -23,6 +23,7 @@ Laghos makefile targets:
    make install
    make clean
    make clean-exec
+   make clean-regtest
    make distclean
    make style
 
@@ -40,6 +41,8 @@ make clean
    Clean the Laghos executable, library and object files.
 make clean-exec
    Clean previous Laghos simulation data files.
+make clean-regtest
+   Clean the regression test output.
 make distclean
    In addition to "make clean", remove the local installation directory and some
    run-time generated files.
@@ -117,7 +120,7 @@ include $(CURDIR)/user.mk
 
 # Targets
 
-.PHONY: all clean distclean install status info opt debug test style clean-build clean-exec
+.PHONY: all clean distclean install status info opt debug test style clean-build clean-exec clean-regtest
 
 .SUFFIXES: .c .cpp .o
 .cpp.o:
@@ -125,8 +128,8 @@ include $(CURDIR)/user.mk
 .c.o:
 	cd $(<D); $(Ccc) -c $(<F)
 
-laghos: override MFEM_DIR = $(MFEM_DIR1)
-include $(CURDIR)/user2.mk
+laghos: $(OBJECT_FILES) $(CONFIG_MK) $(MFEM_LIB_FILE)
+				$(CCC) -o laghos $(OBJECT_FILES) $(LIBS) -Wl,-rpath,$(CURDIR)/../libROM/build -L$(CURDIR)/../libROM/build -lROM $(SCALAPACK_FLAGS)
 
 all: laghos
 
@@ -154,13 +157,18 @@ $(CONFIG_MK) $(MFEM_LIB_FILE):
 	$(error The MFEM library is not built)
 
 
-clean: clean-build clean-exec
+clean: clean-build
 
 clean-build:
 	rm -rf laghos *.o *~ *.dSYM run
+
 clean-exec:
+	rm -f twpTemp.csv
 	rm -rf run/ROMsol/*
 	(cd run && (ls | grep -v ROMsol | xargs rm -rf))
+
+clean-regtest: clean-exec
+	rm -rf tests/Laghos tests/fileComparator tests/basisComparator tests/results
 
 distclean: clean
 	rm -rf bin/

--- a/makefile
+++ b/makefile
@@ -23,6 +23,7 @@ Laghos makefile targets:
    make install
    make clean
    make clean-exec
+   make clean-regtest
    make distclean
    make style
 
@@ -40,6 +41,8 @@ make clean
    Clean the Laghos executable, library and object files.
 make clean-exec
    Clean previous Laghos simulation data files.
+make clean-regtest
+   Clean the regression test output.
 make distclean
    In addition to "make clean", remove the local installation directory and some
    run-time generated files.
@@ -117,7 +120,7 @@ include $(CURDIR)/user.mk
 
 # Targets
 
-.PHONY: all clean distclean install status info opt debug test style clean-build clean-exec
+.PHONY: all clean distclean install status info opt debug test style clean-build clean-exec clean-regtest
 
 .SUFFIXES: .c .cpp .o
 .cpp.o:
@@ -125,8 +128,8 @@ include $(CURDIR)/user.mk
 .c.o:
 	cd $(<D); $(Ccc) -c $(<F)
 
-laghos: override MFEM_DIR = $(MFEM_DIR1)
-include $(CURDIR)/user2.mk
+laghos: $(OBJECT_FILES) $(CONFIG_MK) $(MFEM_LIB_FILE)
+				$(CCC) -o laghos $(OBJECT_FILES) $(LIBS) -Wl,-rpath,$(CURDIR)/../libROM/build -L$(CURDIR)/../libROM/build -lROM $(SCALAPACK_FLAGS)
 
 all: laghos
 
@@ -154,13 +157,18 @@ $(CONFIG_MK) $(MFEM_LIB_FILE):
 	$(error The MFEM library is not built)
 
 
-clean: clean-build clean-exec
+clean: clean-regtest clean-build
 
 clean-build:
 	rm -rf laghos *.o *~ *.dSYM run
+
 clean-exec:
+	rm -f twpTemp.csv
 	rm -rf run/ROMsol/*
 	(cd run && (ls | grep -v ROMsol | xargs rm -rf))
+
+clean-regtest: clean-exec
+	rm -rf tests/Laghos tests/fileComparator tests/basisComparator tests/results
 
 distclean: clean
 	rm -rf bin/

--- a/makefile
+++ b/makefile
@@ -157,7 +157,7 @@ $(CONFIG_MK) $(MFEM_LIB_FILE):
 	$(error The MFEM library is not built)
 
 
-clean: clean-build
+clean: clean-regtest clean-build
 
 clean-build:
 	rm -rf laghos *.o *~ *.dSYM run


### PR DESCRIPTION
I have changed the code to work with the regression tests and the new libROM master branch. I will do a pull request for the regression tests themselves right after this is merged. This is necessary so that the baseline branch will work correctly when we do a git clone during the regression tests.

Merging this pull request will cause your Laghos to fail unless you do a git pull on libROM master branch and re-compile libROM. as I made some small change there to the CMakeFile to get it to work with MAC. 

Also, user2.mk is now unnecessary. We only need user.mk with scalapackflags and astyle defined.