### PR TITLE
Windowing by number of snapshots

### DIFF
--- a/laghos_rom.hpp
+++ b/laghos_rom.hpp
@@ -118,6 +118,11 @@ public:
 
     void Finalize(const double t, const double dt, Vector const& S, Array<int> &cutoff);
 
+    int MaxNumSamples()
+    {
+        return std::max(std::max(generator_X->getNumSamples(), generator_V->getNumSamples()), generator_E->getNumSamples());
+    }
+
 private:
     const int H1size;
     const int L2size;


### PR DESCRIPTION
This PR adds the capability to define ROM time windows in the offline phase by a fixed number of snapshots for the basis generator in each window. The online phase still works as before. This PR depends on libROM PR 34. 