### PR TITLE
Match time window changes online

### DIFF
--- a/laghos.cpp
+++ b/laghos.cpp
@@ -893,6 +893,9 @@ int main(int argc, char *argv[])
                 last_step = true;
             }
 
+            if (rom_online && usingWindows && (t + dt >= twep[rom_window]))
+                dt = twep[rom_window] - t;
+
             if (steps == max_tsteps) {
                 last_step = true;
             }

--- a/laghos.cpp
+++ b/laghos.cpp
@@ -719,7 +719,8 @@ int main(int argc, char *argv[])
     // defines the Mult() method that is used by the time integrators.
     if (!rom_online) ode_solver->Init(oper);
     oper.ResetTimeStepEstimate();
-    double t = 0.0, dt = oper.GetTimeStepEstimate(S), t_old;
+    double t = 0.0, dt = oper.GetTimeStepEstimate(S), t_old, dt_old;
+    bool use_dt_old = false;
     bool last_step = false;
     int steps = 0;
     BlockVector S_old(S);
@@ -893,8 +894,18 @@ int main(int argc, char *argv[])
                 last_step = true;
             }
 
+            if ( use_dt_old ) 
+            {
+                dt = dt_old;
+                use_dt_old = false;
+            }
+
             if (rom_online && usingWindows && (t + dt >= twep[rom_window]))
+            {
+                dt_old = dt;
+                use_dt_old = true;
                 dt = twep[rom_window] - t;
+            }
 
             if (steps == max_tsteps) {
                 last_step = true;

--- a/laghos_csv.hpp
+++ b/laghos_csv.hpp
@@ -47,7 +47,7 @@ int ReadTimeWindows(const int nw, std::string twfile, Array<double>& twep, const
             return 2;  // incorrect number of parameters
         }
 
-        twep[count] = stof(row[0]);
+        twep[count] = stod(row[0]);
 
         if (printStatus) cout << "Using time window " << count << " with end time " << twep[count] << endl;
         count++;
@@ -110,7 +110,7 @@ int ReadTimeWindowParameters(const int nw, std::string twfile, Array<double>& tw
             return 2;  // incorrect number of parameters
         }
 
-        twep[count] = stof(row[0]);
+        twep[count] = stod(row[0]);
         for (int i=0; i<nparamRead-1; ++i)
             twparam(count,i) = stoi(row[i+1]);
 


### PR DESCRIPTION
This PR resets the timestep `dt` so that online timesteps exactly match time window changes. This could result in an extremely small timestep at a window change, which is not checked. If this causes problems, it should be easy to notice the small `dt` in the output. Also, times are now read from the CSV file as doubles (previously as floats, causing some round-off in the window definitions). One test (Gresho) already showed that this change decreases the online ROM error significantly.