### PR TITLE
Window overlap

### DIFF
--- a/laghos.cpp
+++ b/laghos.cpp
@@ -181,6 +181,7 @@ int main(int argc, char *argv[])
     bool writeSol = false;
     bool solDiff = false;
     bool rom_hyperreduce = false;
+    bool match_end_time = false;
     int rom_sample_dim = 0;
     const char *normtype_char = "l2";
     Array<double> twep;
@@ -224,6 +225,8 @@ int main(int argc, char *argv[])
                    "Enable or disable GLVis visualization.");
     args.AddOption(&vis_steps, "-vs", "--visualization-steps",
                    "Visualize every n-th timestep.");
+    args.AddOption(&match_end_time, "-met", "--match-end-time", "-no-met", "--no-match-end-time",
+                   "Match the end time of each window.");
     args.AddOption(&visit, "-visit", "--visit", "-no-visit", "--no-visit",
                    "Enable or disable VisIt visualization.");
     args.AddOption(&gfprint, "-print", "--print", "-no-print", "--no-print",
@@ -905,7 +908,7 @@ int main(int argc, char *argv[])
                 use_dt_old = false;
             }
 
-            if (rom_online && usingWindows && (t + dt >= twep[rom_window]))
+            if (rom_online && usingWindows && (t + dt >= twep[rom_window]) & match_end_time)
             {
                 dt_old = dt;
                 use_dt_old = true;


### PR DESCRIPTION
This PR implements ROM time window overlap by a user-specified number of samples (default no overlap). 

For `j=0,1,2,...` window `j` contains samples (roughly, plus or minus one)

`[j*n,(j+1)*n + p]`

where `n` is the number of window samples (`-nwinsamp`), and `p` is the number of overlap samples (`-nwinover`). Thus overlap is forward, not backward, for simple implementation. In order for the online ROM windows to have maximal overlap, the end time for window `j` is chosen from sample `(j+1)*n + (p/2)`. This means the window ends in the middle of the overlap, where "middle" is with respect to number of samples rather than physical time. Also, the window length is `n + (p/2)` samples, rather than `n`, which may be a little confusing.

Greatly reduced ROM error has been observed with this feature, for the Gresho test, e.g. offline and online runs

`srun -n 8 -p pdebug laghos -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.62 -s 7 -visit -vs 10 -offline -ef 0.9999 -romsvds -nwinsamp 250 -nwinover 100`

`srun -n 8 -p pdebug laghos -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.62 -s 7 -visdiff 758 -vs 10 -online -romhr -romsvds -nwin 3 -twp twpTemp.csv -sfacx 100 -sfacv 100 -sface 100`
