### PR TITLE
ROM offset

### DIFF
--- a/laghos.cpp
+++ b/laghos.cpp
@@ -757,6 +757,13 @@ int main(int argc, char *argv[])
     Vector romS, romS_old;
     ROM_Operator *romOper = NULL;
 
+    if (!usingWindows)
+    {
+        if (numSampX == 0) numSampX = sFactorX * rom_dimx;
+        if (numSampV == 0) numSampV = sFactorV * rom_dimv;
+        if (numSampE == 0) numSampE = sFactorE * rom_dime;
+    }
+
     StopWatch onlinePreprocessTimer;
     if (rom_online)
     {

--- a/laghos.cpp
+++ b/laghos.cpp
@@ -162,7 +162,7 @@ int main(int argc, char *argv[])
     bool rom_online = false;
     bool rom_restore = false;
     bool rom_staticSVD = false;
-    bool rom_offsetX0 = false;
+    bool rom_offset = false;
     double rom_energyFraction = 0.9999;
     int rom_dimx = -1;
     int rom_dimv = -1;
@@ -276,6 +276,8 @@ int main(int argc, char *argv[])
                    "Enable or disable ROM hyperreduction.");
     args.AddOption(&rom_staticSVD, "-romsvds", "--romsvdstatic", "-no-romsvds", "--no-romsvds",
                    "Enable or disable ROM static SVD.");
+    args.AddOption(&rom_offset, "-romos", "--romoffset", "-no-romoffset", "--no-romoffset",
+                   "Enable or disable initial state offset for ROM.");
     args.AddOption(&normtype_char, "-normtype", "--norm_type", "Norm type for relative error computation.");
     args.AddOption(&rom_sample_dim, "-sdim", "--sdim", "ROM max sample dimension");
     args.Parse();
@@ -746,7 +748,7 @@ int main(int argc, char *argv[])
             outfile_twp.open("twpTemp.csv");
         }
         const double tf = (usingWindows && windowNumSamples == 0) ? twep[0] : t_final;
-        sampler = new ROM_Sampler(myid, &H1FESpace, &L2FESpace, tf, dt, S, rom_staticSVD, rom_offsetX0, rom_energyFraction, rom_window, rom_sample_dim);
+        sampler = new ROM_Sampler(myid, &H1FESpace, &L2FESpace, tf, dt, S, rom_staticSVD, rom_offset, rom_energyFraction, rom_window, rom_sample_dim);
         sampler->SampleSolution(0, 0, S);
         samplerTimer.Stop();
     }
@@ -771,7 +773,7 @@ int main(int argc, char *argv[])
         }
         basis = new ROM_Basis(MPI_COMM_WORLD, &H1FESpace, &L2FESpace, rom_dimx, rom_dimv, rom_dime,
                               numSampX, numSampV, numSampE,
-                              rom_staticSVD, rom_hyperreduce, rom_offsetX0);
+                              rom_staticSVD, rom_hyperreduce, rom_offset);
         romS.SetSize(rom_dimx + rom_dimv + rom_dime);
         basis->ProjectFOMtoROM(S, romS);
 
@@ -798,11 +800,11 @@ int main(int argc, char *argv[])
             rom_dime = twparam(rom_window,2);
             basis = new ROM_Basis(MPI_COMM_WORLD, &H1FESpace, &L2FESpace, rom_dimx, rom_dimv, rom_dime,
                                   numSampX, numSampV, numSampE,
-                                  rom_staticSVD, rom_hyperreduce, rom_offsetX0, rom_window);
+                                  rom_staticSVD, rom_hyperreduce, rom_offset, rom_window);
         } else {
             basis = new ROM_Basis(MPI_COMM_WORLD, &H1FESpace, &L2FESpace, rom_dimx, rom_dimv, rom_dime,
                                   numSampX, numSampV, numSampE,
-                                  rom_staticSVD, rom_hyperreduce, rom_offsetX0);
+                                  rom_staticSVD, rom_hyperreduce, rom_offset);
         }
         int romSsize = rom_dimx + rom_dimv + rom_dime;
         romS.SetSize(romSsize);
@@ -860,7 +862,7 @@ int main(int argc, char *argv[])
                 delete basis;
                 basis = new ROM_Basis(MPI_COMM_WORLD, &H1FESpace, &L2FESpace, rom_dimx, rom_dimv, rom_dime,
                                       numSampX, numSampV, numSampE,
-                                      rom_staticSVD, rom_hyperreduce, rom_offsetX0, rom_window);
+                                      rom_staticSVD, rom_hyperreduce, rom_offset, rom_window);
                 romSsize = rom_dimx + rom_dimv + rom_dime;
                 romS.SetSize(romSsize);
             }
@@ -902,7 +904,7 @@ int main(int argc, char *argv[])
                 last_step = true;
             }
 
-            if ( use_dt_old ) 
+            if ( use_dt_old )
             {
                 dt = dt_old;
                 use_dt_old = false;
@@ -1050,7 +1052,7 @@ int main(int argc, char *argv[])
 
                     rom_window++;
                     const double tf = (usingWindows && windowNumSamples == 0) ? twep[rom_window] : t_final;
-                    sampler = new ROM_Sampler(myid, &H1FESpace, &L2FESpace, tf, dt, S, rom_staticSVD, rom_offsetX0, rom_energyFraction, rom_window, rom_sample_dim);
+                    sampler = new ROM_Sampler(myid, &H1FESpace, &L2FESpace, tf, dt, S, rom_staticSVD, rom_offset, rom_energyFraction, rom_window, rom_sample_dim);
                     sampler->SampleSolution(t, dt, S);
                 }
                 samplerTimer.Stop();
@@ -1081,7 +1083,7 @@ int main(int argc, char *argv[])
                     timeLoopTimer.Stop();
                     basis = new ROM_Basis(MPI_COMM_WORLD, &H1FESpace, &L2FESpace, rom_dimx, rom_dimv, rom_dime,
                                           numSampX, numSampV, numSampE,
-                                          rom_staticSVD, rom_hyperreduce, rom_offsetX0, rom_window);
+                                          rom_staticSVD, rom_hyperreduce, rom_offset, rom_window);
                     romS.SetSize(rom_dimx + rom_dimv + rom_dime);
                     timeLoopTimer.Start();
 

--- a/laghos_rom.cpp
+++ b/laghos_rom.cpp
@@ -277,6 +277,18 @@ ROM_Basis::ROM_Basis(MPI_Comm comm_, ParFiniteElementSpace *H1FESpace, ParFinite
     dimV = rdimv;
     dimE = rdime;
 
+    if (offsetInit)
+    {
+        initX = new CAROM::Vector(tH1size, true);
+        initX->read("run/ROMoffset/initX" + std::to_string(window));
+
+        initV = new CAROM::Vector(tH1size, true);
+        initV->read("run/ROMoffset/initV" + std::to_string(window));
+
+        initE = new CAROM::Vector(tL2size, true);
+        initE->read("run/ROMoffset/initE" + std::to_string(window));
+    }
+
     if (hyperreduce)
     {
         if(rank == 0) cout << "start preprocessing hyper-reduction\n";
@@ -817,15 +829,6 @@ void ROM_Basis::SetupHyperreduction(ParFiniteElementSpace *H1FESpace, ParFiniteE
 
     if (offsetInit)
     {
-        initX = new CAROM::Vector(tH1size, true);
-        initX->read("run/ROMoffset/initX" + std::to_string(window));
-
-        initV = new CAROM::Vector(tH1size, true);
-        initV->read("run/ROMoffset/initV" + std::to_string(window));
-
-        initE = new CAROM::Vector(tL2size, true);
-        initE->read("run/ROMoffset/initE" + std::to_string(window));
-
         CAROM::Matrix FOMX0(tH1size, 2, true);
 
         for (int i=0; i<tH1size; ++i)

--- a/laghos_rom.hpp
+++ b/laghos_rom.hpp
@@ -110,7 +110,7 @@ public:
                 (*initX)(i) = X[i];
             }
 
-            initX->write("initX");
+            initX->write("run/ROMoffset/initX" + std::to_string(window));
         }
     }
 
@@ -311,7 +311,7 @@ private:
     int numSamplesV = 0;
     int numSamplesE = 0;
 
-    void SetupHyperreduction(ParFiniteElementSpace *H1FESpace, ParFiniteElementSpace *L2FESpace, Array<int>& nH1);
+    void SetupHyperreduction(ParFiniteElementSpace *H1FESpace, ParFiniteElementSpace *L2FESpace, Array<int>& nH1, const int window);
 };
 
 class ROM_Operator : public TimeDependentOperator

--- a/laghos_rom.hpp
+++ b/laghos_rom.hpp
@@ -32,12 +32,12 @@ class ROM_Sampler
 public:
     ROM_Sampler(const int rank_, ParFiniteElementSpace *H1FESpace, ParFiniteElementSpace *L2FESpace,
                 const double t_final, const double initial_dt, Vector const& S_init,
-                const bool staticSVD = false, const bool useXoffset = false, double energyFraction_=0.9999,
+                const bool staticSVD = false, const bool useOffset = false, double energyFraction_=0.9999,
                 const int window=0, const int max_dim=0)
         : rank(rank_), tH1size(H1FESpace->GetTrueVSize()), tL2size(L2FESpace->GetTrueVSize()),
           H1size(H1FESpace->GetVSize()), L2size(L2FESpace->GetVSize()),
           X(tH1size), dXdt(tH1size), V(tH1size), dVdt(tH1size), E(tL2size), dEdt(tL2size),
-          gfH1(H1FESpace), gfL2(L2FESpace), offsetXinit(useXoffset), energyFraction(energyFraction_)
+          gfH1(H1FESpace), gfL2(L2FESpace), offsetInit(useOffset), energyFraction(energyFraction_)
     {
         // TODO: read the following parameters from input?
         double model_linearity_tol = 1.e-7;
@@ -101,16 +101,30 @@ public:
         V0 = 0.0;
         E0 = 0.0;
 
-        if (offsetXinit)
+        if (offsetInit)
         {
             initX = new CAROM::Vector(tH1size, true);
+            initV = new CAROM::Vector(tH1size, true);
+            initE = new CAROM::Vector(tL2size, true);
             Xdiff.SetSize(tH1size);
+            Ediff.SetSize(tL2size);
+
             for (int i=0; i<tH1size; ++i)
             {
                 (*initX)(i) = X[i];
             }
-
             initX->write("run/ROMoffset/initX" + std::to_string(window));
+
+            for (int i=0; i<tH1size; ++i)
+            {
+                (*initV)(i) = V[i];
+            }
+            initV->write("run/ROMoffset/initV" + std::to_string(window));
+            for (int i=0; i<tL2size; ++i)
+            {
+                (*initE)(i) = E[i];
+            }
+            initE->write("run/ROMoffset/initE" + std::to_string(window));
         }
     }
 
@@ -134,10 +148,12 @@ private:
 
     CAROM::SVDBasisGenerator *generator_X, *generator_V, *generator_E;
 
-    Vector X, X0, Xdiff, dXdt, V, V0, dVdt, E, E0, dEdt;
+    Vector X, X0, Xdiff, Ediff, dXdt, V, V0, dVdt, E, E0, dEdt;
 
-    const bool offsetXinit;
+    const bool offsetInit;
     CAROM::Vector *initX = 0;
+    CAROM::Vector *initV = 0;
+    CAROM::Vector *initE = 0;
 
     ParGridFunction gfH1, gfL2;
 
@@ -254,7 +270,7 @@ public:
 private:
     const bool staticSVD;
     const bool hyperreduce;
-    const bool offsetXinit;
+    const bool offsetInit;
     int rdimx, rdimv, rdime;
 
     int nprocs, rank, rowOffsetH1, rowOffsetL2;
@@ -305,7 +321,11 @@ private:
     CAROM::Matrix *BsinvE = NULL;
 
     CAROM::Vector *initX = 0;
+    CAROM::Vector *initV = 0;
+    CAROM::Vector *initE = 0;
     CAROM::Vector *initXsp = 0;
+    CAROM::Vector *initVsp = 0;
+    CAROM::Vector *initEsp = 0;
 
     int numSamplesX = 0;
     int numSamplesV = 0;

--- a/makefile
+++ b/makefile
@@ -166,6 +166,7 @@ clean-build:
 clean-exec:
 	rm -f twpTemp.csv
 	rm -rf run/ROMsol/*
+	rm -rf run/ROMoffset/*
 	(cd run && (ls | grep -v ROMsol | xargs rm -rf))
 
 clean-regtest: clean-exec
@@ -199,3 +200,4 @@ style:
 
 $(shell mkdir -p run)
 $(shell mkdir -p run/ROMsol)
+$(shell mkdir -p run/ROMoffset)


### PR DESCRIPTION
This PR enables offsetting the ROM spaces for X, V, and E by the initial state of the variables. To enable, use command line flag `-romos`. Initial testing showed that the error was significantly reduced, but the ROM basis sizes were larger, so it is unclear whether the offset or the larger bases or both are the cause for better accuracy.