### PR TITLE
Fix offsets for time derivatives

### DIFF
--- a/laghos_rom.hpp
+++ b/laghos_rom.hpp
@@ -234,7 +234,8 @@ public:
 
     void ReadSolutionBases(const int window);
 
-    void ProjectFOMtoROM(Vector const& f, Vector & r);
+    void ProjectFOMtoROM(Vector const& f, Vector & r,
+                         const bool timeDerivative=false);
     void LiftROMtoFOM(Vector const& r, Vector & f);
     int TotalSize() {
         return rdimx + rdimv + rdime;
@@ -257,7 +258,8 @@ public:
     }
 
     void LiftToSampleMesh(const Vector &x, Vector &xsp) const;
-    void RestrictFromSampleMesh(const Vector &xsp, Vector &x) const;
+    void RestrictFromSampleMesh(const Vector &xsp, Vector &x,
+                                const bool timeDerivative=false) const;
 
     int GetRank() const {
         return rank;


### PR DESCRIPTION
When using offsets for variable x, i.e. x0 = x(t=0), we approximate x by \tilde{x} = x0 + Bc where B is a basis for (x-x0), and c is the vector of ROM coefficients. The projection of x is computed by c = B^T (x-x0). For time derivatives, d\tilde{x}/dt = B(dc/dt) and the projection of xdot should be dc/dt = B^T xdot. The code was incorrectly subtracting x0 from xdot here, and this PR fixes that.

This affects tests using RK4 but not RK2Avg, e.g. the Gresho test, as the RK2Avg computes S rather than dS/dt. One Sedov test with RK4 showed dramatically reduced error with the changes in this PR.