### PR TITLE
Parametric ROM

### DIFF
--- a/laghos.cpp
+++ b/laghos.cpp
@@ -183,6 +183,8 @@ int main(int argc, char *argv[])
     bool rom_hyperreduce = false;
     bool match_end_time = false;
     int rom_sample_dim = 0;
+    double rhoFactor = 1.0;
+    int rom_paramID = -1;
     const char *normtype_char = "l2";
     Array<double> twep;
     Array2D<int> twparam;
@@ -280,6 +282,8 @@ int main(int argc, char *argv[])
                    "Enable or disable initial state offset for ROM.");
     args.AddOption(&normtype_char, "-normtype", "--norm_type", "Norm type for relative error computation.");
     args.AddOption(&rom_sample_dim, "-sdim", "--sdim", "ROM max sample dimension");
+    args.AddOption(&rhoFactor, "-rhof", "--rhofactor", "Factor for scaling rho.");
+    args.AddOption(&rom_paramID, "-rpar", "--romparam", "ROM offline parameter index.");
     args.Parse();
     if (!args.Good())
     {
@@ -600,7 +604,8 @@ int main(int argc, char *argv[])
     // this density is a temporary function and it will not be updated during the
     // time evolution.
     ParGridFunction rho(&L2FESpace);
-    FunctionCoefficient rho_coeff(rho0);
+    FunctionCoefficient rho_coeff0(rho0);
+    ProductCoefficient rho_coeff(rhoFactor, rho_coeff0);
     L2_FECollection l2_fec(order_e, pmesh->Dimension());
     ParFiniteElementSpace l2_fes(pmesh, &l2_fec);
     ParGridFunction l2_rho(&l2_fes), l2_e(&l2_fes);
@@ -748,7 +753,8 @@ int main(int argc, char *argv[])
             outfile_twp.open("twpTemp.csv");
         }
         const double tf = (usingWindows && windowNumSamples == 0) ? twep[0] : t_final;
-        sampler = new ROM_Sampler(myid, &H1FESpace, &L2FESpace, tf, dt, S, rom_staticSVD, rom_offset, rom_energyFraction, rom_window, rom_sample_dim);
+        sampler = new ROM_Sampler(myid, &H1FESpace, &L2FESpace, tf, dt, S, rom_staticSVD, rom_offset,
+                                  rom_energyFraction, rom_window, rom_sample_dim, rom_paramID);
         sampler->SampleSolution(0, 0, S);
         samplerTimer.Stop();
     }
@@ -1059,7 +1065,8 @@ int main(int argc, char *argv[])
 
                     rom_window++;
                     const double tf = (usingWindows && windowNumSamples == 0) ? twep[rom_window] : t_final;
-                    sampler = new ROM_Sampler(myid, &H1FESpace, &L2FESpace, tf, dt, S, rom_staticSVD, rom_offset, rom_energyFraction, rom_window, rom_sample_dim);
+                    sampler = new ROM_Sampler(myid, &H1FESpace, &L2FESpace, tf, dt, S, rom_staticSVD, rom_offset,
+                                              rom_energyFraction, rom_window, rom_sample_dim, rom_paramID);
                     sampler->SampleSolution(t, dt, S);
                 }
                 samplerTimer.Stop();

--- a/laghos_rom.cpp
+++ b/laghos_rom.cpp
@@ -143,7 +143,10 @@ void ROM_Sampler::Finalize(const double t, const double dt, Vector const& S, Arr
     else
         generator_X->takeSample(X.GetData(), t, dt);
 
-    generator_X->endSamples();
+    if (writeSnapshots)
+        generator_X->writeSnapshot();
+    else
+        generator_X->endSamples();
 
     if (offsetInit)
     {
@@ -157,7 +160,10 @@ void ROM_Sampler::Finalize(const double t, const double dt, Vector const& S, Arr
     else
         generator_V->takeSample(V.GetData(), t, dt);
 
-    generator_V->endSamples();
+    if (writeSnapshots)
+        generator_V->writeSnapshot();
+    else
+        generator_V->endSamples();
 
     if (offsetInit)
     {
@@ -171,9 +177,12 @@ void ROM_Sampler::Finalize(const double t, const double dt, Vector const& S, Arr
     else
         generator_E->takeSample(E.GetData(), t, dt);
 
-    generator_E->endSamples();
+    if (writeSnapshots)
+        generator_E->writeSnapshot();
+    else
+        generator_E->endSamples();
 
-    if (rank == 0)
+    if (rank == 0 && !writeSnapshots)
     {
         cout << "X basis summary output: ";
         BasisGeneratorFinalSummary(generator_X, energyFraction, cutoff[0]);
@@ -902,12 +911,6 @@ int ROM_Basis::SolutionSizeFOM() const
 
 void ROM_Basis::ReadSolutionBases(const int window)
 {
-    /*
-    basisX = ReadBasisROM(rank, ROMBasisName::X, H1size, (staticSVD ? rowOffsetH1 : 0), rdimx);
-    basisV = ReadBasisROM(rank, ROMBasisName::V, H1size, (staticSVD ? rowOffsetH1 : 0), rdimv);
-    basisE = ReadBasisROM(rank, ROMBasisName::E, L2size, (staticSVD ? rowOffsetL2 : 0), rdime);
-    */
-
     basisX = ReadBasisROM(rank, ROMBasisName::X + std::to_string(window), tH1size, 0, rdimx);
     basisV = ReadBasisROM(rank, ROMBasisName::V + std::to_string(window), tH1size, 0, rdimv);
     basisE = ReadBasisROM(rank, ROMBasisName::E + std::to_string(window), tL2size, 0, rdime);
@@ -1078,7 +1081,7 @@ void ROM_Basis::RestrictFromSampleMesh(const Vector &usp, Vector &u, const bool 
 }
 
 ROM_Operator::ROM_Operator(hydrodynamics::LagrangianHydroOperator *lhoper, ROM_Basis *b,
-                           FunctionCoefficient& rho_coeff, FunctionCoefficient& mat_coeff,
+                           Coefficient& rho_coeff, FunctionCoefficient& mat_coeff,
                            const int order_e, const int source, const bool visc, const double cfl,
                            const bool p_assembly, const double cg_tol, const int cg_max_iter,
                            const double ftz_tol, const bool hyperreduce_, H1_FECollection *H1fec,

--- a/makefile
+++ b/makefile
@@ -129,7 +129,10 @@ include $(CURDIR)/user.mk
 laghos: $(OBJECT_FILES) $(CONFIG_MK) $(MFEM_LIB_FILE)
 				$(CCC) -o laghos $(OBJECT_FILES) $(LIBS) -Wl,-rpath,$(LIBS_DIR)/libROM/build -L$(LIBS_DIR)/libROM/build -lROM $(SCALAPACK_FLAGS)
 
-all: laghos
+merge: merge.o $(CONFIG_MK) $(MFEM_LIB_FILE)
+				$(CCC) -o merge merge.o $(LIBS) -Wl,-rpath,$(LIBS_DIR)/libROM/build -L$(LIBS_DIR)/libROM/build -lROM $(SCALAPACK_FLAGS)
+
+all: laghos merge
 
 opt:
 	$(MAKE) "LAGHOS_DEBUG=NO"
@@ -158,7 +161,7 @@ $(CONFIG_MK) $(MFEM_LIB_FILE):
 clean: clean-regtest clean-build
 
 clean-build:
-	rm -rf laghos *.o *~ *.dSYM run
+	rm -rf laghos *.o *~ *.dSYM run merge
 
 clean-exec:
 	rm -f twpTemp.csv
@@ -188,7 +191,7 @@ status info:
 	@true
 
 #ASTYLE = astyle --options=$(MFEM_DIR1)/config/mfem.astylerc
-FORMAT_FILES := $(SOURCE_FILES) $(HEADER_FILES) $(TEST_FILES)
+FORMAT_FILES := $(SOURCE_FILES) $(HEADER_FILES) $(TEST_FILES) merge.cpp
 
 style:
 	@if ! $(ASTYLE) $(FORMAT_FILES) | grep Formatted; then\

--- a/merge.cpp
+++ b/merge.cpp
@@ -1,0 +1,155 @@
+#include "mfem.hpp"
+
+#include "StaticSVDBasisGenerator.h"
+#include "BasisReader.h"
+
+using namespace std;
+using namespace mfem;
+
+
+void BasisGeneratorFinalSummary(CAROM::SVDBasisGenerator* bg, const double energyFraction)
+{
+    int cutoff = 0;
+    const int rom_dim = bg->getSpatialBasis()->numColumns();
+    const CAROM::Matrix* sing_vals = bg->getSingularValues();
+
+    MFEM_VERIFY(rom_dim == sing_vals->numColumns(), "");
+
+    double sum = 0.0;
+    for (int sv = 0; sv < sing_vals->numColumns(); ++sv) {
+        sum += (*sing_vals)(sv, sv);
+    }
+
+    double partialSum = 0.0;
+    for (int sv = 0; sv < sing_vals->numColumns(); ++sv) {
+        partialSum += (*sing_vals)(sv, sv);
+        if (partialSum / sum > energyFraction)
+        {
+            cutoff = sv+1;
+            break;
+        }
+    }
+
+    cout << "Take first " << cutoff << " of " << sing_vals->numColumns() << " basis vectors" << endl;
+}
+
+void PrintSingularValues(const int rank, const std::string& name, CAROM::SVDBasisGenerator* bg)
+{
+    const CAROM::Matrix* sing_vals = bg->getSingularValues();
+
+    char tmp[100];
+    sprintf(tmp, ".%06d", rank);
+
+    std::string fullname = "run/sVal" + name + tmp;
+
+    std::ofstream ofs(fullname.c_str(), std::ofstream::out);
+    ofs.precision(16);
+
+    for (int sv = 0; sv < sing_vals->numColumns(); ++sv) {
+        ofs << (*sing_vals)(sv, sv) << endl;
+    }
+
+    ofs.close();
+}
+
+void LoadSampleSets(const int rank, const double energyFraction, const int nsets, const std::string& varName,
+                    const int dim, const int totalSamples)
+{
+    std::unique_ptr<CAROM::SVDBasisGenerator> basis_generator;
+
+    std::string basis_filename = "run/basis" + varName + "0";  // 0 is the time window index
+    basis_generator.reset(new CAROM::StaticSVDBasisGenerator(dim, totalSamples, basis_filename));
+
+    cout << "Loading snapshots for " << varName << endl;
+
+    for (int i=0; i<nsets; ++i)
+    {
+        std::string filename = "run/param" + std::to_string(i) + "_var" + varName + "0_snapshot";  // 0 is time window index
+        basis_generator->loadSamples(filename,"snapshot");
+    }
+
+    //cout << "Saving data uploaded as a snapshot" << endl;
+    //basis_generator->writeSnapshot();
+
+    cout << "Computing SVD for " << varName << endl;
+    basis_generator->endSamples();  // save the basis file
+
+    cout << varName << " basis summary output: ";
+    BasisGeneratorFinalSummary(basis_generator.get(), energyFraction);
+    PrintSingularValues(rank, varName, basis_generator.get());
+}
+
+// id is snapshot index, 0-based
+void GetSnapshotDim(const int id, const std::string& varName, int& varDim, int& numSnapshots)
+{
+    std::string filename = "run/param" + std::to_string(id) + "_var" + varName + "0_snapshot";  // 0 is time window index
+
+    CAROM::BasisReader reader(filename);
+    const CAROM::Matrix *S = reader.getSnapshotMatrix(0.0);
+    varDim = S->numRows();
+    numSnapshots = S->numColumns();
+}
+
+int main(int argc, char *argv[])
+{
+    // Initialize MPI.
+    MPI_Session mpi(argc, argv);
+    int myid = mpi.WorldRank();
+
+    // Parse command-line options.
+    int nset = 0;
+    double energyFraction = 0.9999;
+
+    OptionsParser args(argc, argv);
+    args.AddOption(&nset, "-nset", "--numsets", "Number of sample sets to merge");
+    args.AddOption(&energyFraction, "-ef", "--rom-ef", "Energy fraction for recommended ROM basis sizes.");
+    args.Parse();
+    if (!args.Good())
+    {
+        if (mpi.Root()) {
+            args.PrintUsage(cout);
+        }
+        return 1;
+    }
+    if (mpi.Root()) {
+        args.PrintOptions(cout);
+    }
+
+    if (nset < 2)
+        cout << "More than one set must be specified. No merging is being done." << endl;
+
+    Array<int> snapshotSize(nset);
+    int dimX, dimV, dimE;
+
+    GetSnapshotDim(0, "X", dimX, snapshotSize[0]);
+    {
+        int dummy = 0;
+        GetSnapshotDim(0, "V", dimV, dummy);
+        MFEM_VERIFY(dummy == snapshotSize[0], "Inconsistent snapshot sizes");
+        GetSnapshotDim(0, "E", dimE, dummy);
+        MFEM_VERIFY(dummy == snapshotSize[0], "Inconsistent snapshot sizes");
+    }
+
+    MFEM_VERIFY(dimX == dimV, "Different sizes for X and V");
+
+    int totalSnapshotSize = snapshotSize[0];
+    for (int i=1; i<nset; ++i)
+    {
+        int dummy = 0;
+        int dim = 0;
+        GetSnapshotDim(i, "X", dim, snapshotSize[i]);
+        MFEM_VERIFY(dim == dimX, "Inconsistent snapshot sizes");
+        GetSnapshotDim(i, "V", dim, dummy);
+        MFEM_VERIFY(dim == dimV && dummy == snapshotSize[i], "Inconsistent snapshot sizes");
+        GetSnapshotDim(i, "E", dim, dummy);
+        MFEM_VERIFY(dim == dimE && dummy == snapshotSize[i], "Inconsistent snapshot sizes");
+
+        totalSnapshotSize += snapshotSize[i];
+    }
+
+    LoadSampleSets(myid, energyFraction, nset, "X", dimX, totalSnapshotSize);
+    LoadSampleSets(myid, energyFraction, nset, "V", dimV, totalSnapshotSize);
+    LoadSampleSets(myid, energyFraction, nset, "E", dimE, totalSnapshotSize);
+
+    return 0;
+}


### PR DESCRIPTION
This PR is a work in progress and is not ready to merge yet.

The new executable `merge` can be built with `make merge`, and it should be run with the same number of MPI tasks as the job that ran the simulations. 

First, multiple snapshot sets should be generated by multiple offline simulations with `-rpar` starting at 0, e.g. 

`srun -n 1 -p pdebug laghos -m data/cube01_hex.mesh -pt 211 -tf 0.01 -offline -romsvds -rhof 1.0 -rpar 0`
`srun -n 1 -p pdebug laghos -m data/cube01_hex.mesh -pt 211 -tf 0.01 -offline -romsvds -rhof 1.2 -rpar 1`
`srun -n 1 -p pdebug laghos -m data/cube01_hex.mesh -pt 211 -tf 0.01 -offline -romsvds -rhof 1.4 -rpar 2`

In this example, the `rho` scaling factor `-rhof` is the varying parameter. In the `run` directory, snapshot files `paramJ_varN0_snapshot.rank` are generated, where `J` is the parameter choice index (0-based), `N` is the variable name (`X`, `V`, `E`), `0` is the time window (only 1 supported for now), and `rank` is the MPI rank. Then running

`merge -nset 3 -ef 0.9999` 

will merge the snapshots for each variable, over all parameter indices, generate `basisN0.rank` and `sValN.rank` files, and print out recommended basis sizes corresponding to the prescribed energy fraction.
