### PR TITLE
Timestep estimate fix

### DIFF
--- a/laghos.cpp
+++ b/laghos.cpp
@@ -983,7 +983,7 @@ int main(int argc, char *argv[])
 
                 romOper->UpdateSampleMeshNodes(romS);
 
-                oper.ResetQuadratureData();  // Necessary for oper.GetTimeStepEstimate(S);
+                if (!romOptions.hyperreduce) oper.ResetQuadratureData();  // Necessary for oper.GetTimeStepEstimate(S);
             }
             else
             {

--- a/laghos_rom.cpp
+++ b/laghos_rom.cpp
@@ -18,7 +18,6 @@ void ROM_Sampler::SampleSolution(const double t, const double dt, Vector const& 
     {
         dSdt.SetSize(S.Size());
         lhoper->Mult(S, dSdt);
-        lhoper->GetTimeStepEstimate(S);  // Reset quadrature data after the Mult
     }
 
     if (sampleX)


### PR DESCRIPTION
This PR removes an unnecessary call to `GetTimeStepEstimate` which results in incorrectly high timestep estimates.