### PR TITLE
Using the initial condition as an offset for all the time windows

### DIFF
--- a/laghos.cpp
+++ b/laghos.cpp
@@ -737,7 +737,7 @@ int main(int argc, char *argv[])
     romOptions.window = 0;
     romOptions.FOMoper = &oper;
     romOptions.parameterID = rom_paramID;
-    romOptions.online = rom_online;
+    romOptions.restore = rom_restore;
 
     // Perform time-integration (looping over the time iterations, ti, with a
     // time-step dt). The object oper is of type LagrangianHydroOperator that

--- a/laghos.cpp
+++ b/laghos.cpp
@@ -838,7 +838,10 @@ int main(int argc, char *argv[])
         romS.SetSize(romOptions.dimX + romOptions.dimV + romOptions.dimE);
         basis->ProjectFOMtoROM(S, romS);
 
-        cout << "Offset Style: " << offsetType << endl;
+        if (myid == 0)
+        {
+            cout << "Offset Style: " << offsetType << endl;
+        }
         cout << myid << ": initial romS norm " << romS.Norml2() << endl;
 
         romOper = new ROM_Operator(romOptions, basis, rho_coeff, mat_coeff, order_e, source, visc, cfl, p_assembly,

--- a/laghos.cpp
+++ b/laghos.cpp
@@ -737,6 +737,7 @@ int main(int argc, char *argv[])
     romOptions.window = 0;
     romOptions.FOMoper = &oper;
     romOptions.parameterID = rom_paramID;
+    romOptions.online = rom_online;
 
     // Perform time-integration (looping over the time iterations, ti, with a
     // time-step dt). The object oper is of type LagrangianHydroOperator that

--- a/laghos.cpp
+++ b/laghos.cpp
@@ -284,6 +284,7 @@ int main(int argc, char *argv[])
     args.AddOption(&rom_paramID, "-rpar", "--romparam", "ROM offline parameter index.");
     args.AddOption(&romOptions.paramOffset, "-rparos", "--romparamoffset", "-no-rparos", "--no-romparamoffset",
                    "Enable or disable parametric offset.");
+    args.AddOption(&romOptions.offsetType, "-rostype", "--romoffsettype", "Offset type for initializing ROM windows.");
     args.Parse();
     if (!args.Good())
     {

--- a/laghos.cpp
+++ b/laghos.cpp
@@ -294,7 +294,11 @@ int main(int argc, char *argv[])
     args.AddOption(&rom_paramID, "-rpar", "--romparam", "ROM offline parameter index.");
     args.AddOption(&romOptions.paramOffset, "-rparos", "--romparamoffset", "-no-rparos", "--no-romparamoffset",
                    "Enable or disable parametric offset.");
-    args.AddOption(&romOptions.offsetType, "-rostype", "--romoffsettype", "Offset type for initializing ROM windows.");
+    args.AddOption(&romOptions.offsetType, "-rostype", "--romoffsettype",
+                   "Offset type for initializing ROM windows.\n\t"
+                   "0 -> save and load offset;\n\t"
+                   "1 -> use initial state as offset;\n\t"
+                   "2 -> use solution from previous window as offset");
     args.Parse();
     if (!args.Good())
     {
@@ -311,9 +315,9 @@ int main(int argc, char *argv[])
         const char path_delim = '/';
         std::string::size_type pos = 0;
         do {
-          pos = outputPath.find(path_delim, pos+1);
-          std::string subdir = outputPath.substr(0, pos);
-          mkdir(subdir.c_str(), 0777);
+            pos = outputPath.find(path_delim, pos+1);
+            std::string subdir = outputPath.substr(0, pos);
+            mkdir(subdir.c_str(), 0777);
         }
         while (pos != std::string::npos);
         mkdir((outputPath + "/ROMoffset").c_str(), 0777);

--- a/laghos.cpp
+++ b/laghos.cpp
@@ -61,7 +61,6 @@
 #include "laghos_rom.hpp"
 #include "laghos_utils.hpp"
 #include <fstream>
-#include <map>
 
 #ifndef _WIN32
 #include <sys/stat.h>  // mkdir

--- a/laghos_rom.cpp
+++ b/laghos_rom.cpp
@@ -279,7 +279,7 @@ ROM_Basis::ROM_Basis(ROM_Options const& input, Vector const& S, MPI_Comm comm_)
       rdimx(input.dimX), rdimv(input.dimV), rdime(input.dimE), rdimfv(input.dimFv), rdimfe(input.dimFe),
       numSamplesX(input.sampX), numSamplesV(input.sampV), numSamplesE(input.sampE),
       hyperreduce(input.hyperreduce), offsetInit(input.useOffset), RHSbasis(input.RHSbasis), useGramSchmidt(input.GramSchmidt),
-      RK2AvgFormulation(input.RK2AvgSolver), basename(*input.basename), offsetType(input.offsetType)
+      RK2AvgFormulation(input.RK2AvgSolver), basename(*input.basename)
 {
     MPI_Comm_size(comm, &nprocs);
     MPI_Comm_rank(comm, &rank);
@@ -334,7 +334,7 @@ ROM_Basis::ROM_Basis(ROM_Options const& input, Vector const& S, MPI_Comm comm_)
         // std::string path_init = (parameterID >= 0) ? basename + "/ROMoffset/param" + std::to_string(parameterID) + "_init" : basename + "/ROMoffset/init"; // TODO: Tony PR77
         std::string path_init = basename + "/ROMoffset/init";
 
-        if (input.restore || (input.offsetType == 0 && !input.paramOffset))
+        if (input.restore || (input.offsetType == saveLoadOffset && !input.paramOffset))
         {
             // Restore phase OR Online phase rostype 0: Read the saved offsets
             initX->read(path_init + "X" + std::to_string(input.window));
@@ -343,7 +343,7 @@ ROM_Basis::ROM_Basis(ROM_Options const& input, Vector const& S, MPI_Comm comm_)
 
             cout << "Read init vectors X, V, E with norms " << initX->norm() << ", " << initV->norm() << ", " << initE->norm() << endl;
         }
-        else if (input.offsetType == 0 && input.paramOffset)
+        else if (input.offsetType == saveLoadOffset && input.paramOffset)
         {
             // TODO: Tony interpolation PR 77
             // Online phase rostype 0 parametric: Read the saved offsets and interpolate
@@ -383,7 +383,7 @@ ROM_Basis::ROM_Basis(ROM_Options const& input, Vector const& S, MPI_Comm comm_)
             initV->write(path_init + "V" + std::to_string(input.window));
             initE->write(path_init + "E" + std::to_string(input.window));
         }
-        else if (input.offsetType == 1 && input.window > 0)
+        else if (input.offsetType == useInitialState && input.window > 0)
         {
             // Online phase rostype 1 time window > 0: Read the initial state
             initX->read(path_init + "X0");

--- a/laghos_rom.cpp
+++ b/laghos_rom.cpp
@@ -375,6 +375,9 @@ ROM_Basis::ROM_Basis(ROM_Options const& input, Vector const& S, MPI_Comm comm_)
         initV = new CAROM::Vector(tH1size, true);
         initE = new CAROM::Vector(tL2size, true);
 
+        // std::string path_init = (parameterID >= 0) ? "run/ROMoffset/param" + std::to_string(parameterID) + "_init" : "run/ROMoffset/init"; // TODO: Tony PR77
+        std::string path_init = "run/ROMoffset/init";
+
         if (input.offsetType == 0)
         {
             if (input.paramOffset)
@@ -414,61 +417,58 @@ ROM_Basis::ROM_Basis(ROM_Options const& input, Vector const& S, MPI_Comm comm_)
             }
             else
             {
-                initX->read("run/ROMoffset/initX" + std::to_string(input.window));
-                initV->read("run/ROMoffset/initV" + std::to_string(input.window));
-                initE->read("run/ROMoffset/initE" + std::to_string(input.window));
+                initX->read(path_init + "X" + std::to_string(input.window));
+                initV->read(path_init + "V" + std::to_string(input.window));
+                initE->read(path_init + "E" + std::to_string(input.window));
 
                 cout << "Read init vectors X, V, E with norms " << initX->norm() << ", " << initV->norm() << ", " << initE->norm() << endl;
             }
         }
+        else if (input.offsetType == 1 && input.window > 0)
+        {
+            initX->read(path_init + "X0");
+            initV->read(path_init + "V0");
+            initE->read(path_init + "E0");
+
+            cout << "Read init vectors X, V, E with norms " << initX->norm() << ", " << initV->norm() << ", " << initE->norm() << endl;
+        }
         else
         {
-            if ((input.offsetType == 1 && input.paramOffset && input.window == 0) || input.offsetType == 2)
+            Vector X, V, E;
+
+            for (int i=0; i<H1size; ++i)
             {
-                Vector X, V, E;
-
-                for (int i=0; i<H1size; ++i)
-                {
-                    gfH1[i] = S[i];
-                }
-                gfH1.GetTrueDofs(X);
-                for (int i=0; i<tH1size; ++i)
-                {
-                    (*initX)(i) = X[i];
-                }
-
-                for (int i=0; i<H1size; ++i)
-                {
-                    gfH1[i] = S[H1size+i];
-                }
-                gfH1.GetTrueDofs(V);
-                for (int i=0; i<tH1size; ++i)
-                {
-                    (*initV)(i) = V[i];
-                }
-
-                for (int i=0; i<L2size; ++i)
-                {
-                    gfL2[i] = S[2*H1size+i];
-                }
-                gfL2.GetTrueDofs(E);
-                for (int i=0; i<tL2size; ++i)
-                {
-                    (*initE)(i) = E[i];
-                }
-
-                initX->write("run/ROMoffset/initX0");
-                initV->write("run/ROMoffset/initV0");
-                initE->write("run/ROMoffset/initE0");
+                gfH1[i] = S[i];
             }
-            else
+            gfH1.GetTrueDofs(X);
+            for (int i=0; i<tH1size; ++i)
             {
-                initX->read("run/ROMoffset/initX0");
-                initV->read("run/ROMoffset/initV0");
-                initE->read("run/ROMoffset/initE0");
-
-                cout << "Read init vectors X, V, E with norms " << initX->norm() << ", " << initV->norm() << ", " << initE->norm() << endl;
+                (*initX)(i) = X[i];
             }
+
+            for (int i=0; i<H1size; ++i)
+            {
+                gfH1[i] = S[H1size+i];
+            }
+            gfH1.GetTrueDofs(V);
+            for (int i=0; i<tH1size; ++i)
+            {
+                (*initV)(i) = V[i];
+            }
+
+            for (int i=0; i<L2size; ++i)
+            {
+                gfL2[i] = S[2*H1size+i];
+            }
+            gfL2.GetTrueDofs(E);
+            for (int i=0; i<tL2size; ++i)
+            {
+                (*initE)(i) = E[i];
+            }
+
+            initX->write(path_init + "X" + std::to_string(input.window));
+            initV->write(path_init + "V" + std::to_string(input.window));
+            initE->write(path_init + "E" + std::to_string(input.window));
         }
     }
 

--- a/laghos_rom.cpp
+++ b/laghos_rom.cpp
@@ -358,7 +358,7 @@ ROM_Basis::ROM_Basis(ROM_Options const& input, Vector const& S, MPI_Comm comm_, 
 
         if (input.restore || (input.offsetType == saveLoadOffset && !input.paramOffset))
         {
-            // Restore phase OR Online phase rostype 0: Read the saved offsets
+            // Read offsets in the restore phase or in the online phase of non-parametric save-and-load mode
             initX->read(path_init + "X" + std::to_string(input.window));
             initV->read(path_init + "V" + std::to_string(input.window));
             initE->read(path_init + "E" + std::to_string(input.window));
@@ -368,7 +368,7 @@ ROM_Basis::ROM_Basis(ROM_Options const& input, Vector const& S, MPI_Comm comm_, 
         else if (input.offsetType == saveLoadOffset && input.paramOffset)
         {
             // TODO: Tony interpolation PR 77
-            // Online phase rostype 0 parametric: Read the saved offsets and interpolate
+            // Interpolate and save offset in the online phase of parametric save-and-load mode
             Vector X, V, E;
 
             for (int i=0; i<H1size; ++i)
@@ -407,7 +407,7 @@ ROM_Basis::ROM_Basis(ROM_Options const& input, Vector const& S, MPI_Comm comm_, 
         }
         else if (input.offsetType == useInitialState && input.window > 0)
         {
-            // Online phase rostype 1 time window > 0: Read the initial state
+            // Read offset in the online phase of initial mode
             initX->read(path_init + "X0");
             initV->read(path_init + "V0");
             initE->read(path_init + "E0");
@@ -416,7 +416,7 @@ ROM_Basis::ROM_Basis(ROM_Options const& input, Vector const& S, MPI_Comm comm_, 
         }
         else
         {
-            // Online phase rostype 1 time window 0 OR Online phase rostype 2: Compute and save offsets
+            // Compute and save offset in the online phase of previous mode or initial window of initial mode
             Vector X, V, E;
 
             for (int i=0; i<H1size; ++i)

--- a/laghos_rom.cpp
+++ b/laghos_rom.cpp
@@ -386,7 +386,7 @@ ROM_Basis::ROM_Basis(ROM_Options const& input, Vector const& S, MPI_Comm comm_)
 
             cout << "Read init vectors X, V, E with norms " << initX->norm() << ", " << initV->norm() << ", " << initE->norm() << endl;
         }
-        else if (!input.online || (input.offsetType == 0 && !input.paramOffset))
+        else if (input.restore || (input.offsetType == 0 && !input.paramOffset))
         {
             initX->read(path_init + "X" + std::to_string(input.window));
             initV->read(path_init + "V" + std::to_string(input.window));
@@ -433,7 +433,7 @@ ROM_Basis::ROM_Basis(ROM_Options const& input, Vector const& S, MPI_Comm comm_)
             initV->write(path_init + "V" + std::to_string(input.window));
             initE->write(path_init + "E" + std::to_string(input.window));
         }
-        else // online, type 1 window 0 or type 2
+        else // online phase, type 1 window 0 or type 2
         {
             Vector X, V, E;
 

--- a/laghos_rom.hpp
+++ b/laghos_rom.hpp
@@ -40,6 +40,7 @@ struct ROM_Options
     double t_final = 0.0; // simulation final time
     double initial_dt = 0.0; // initial timestep size
 
+    bool online = false; // if true, online phase
     bool staticSVD = false; // true: use StaticSVDBasisGenerator; false: use IncrementalSVDBasisGenerator
     bool useOffset = false; // if true, sample variables minus initial state as an offset
     bool RHSbasis = false; // if true, use bases for nonlinear RHS terms without mass matrix inverses applied

--- a/laghos_rom.hpp
+++ b/laghos_rom.hpp
@@ -222,14 +222,14 @@ public:
 
             if (input.offsetType == useInitialState && input.window > 0)
             {
-                // Offline phase rostype 1 time window > 0: Read the initial state
+                // Read the initial state in the offline phase
                 initX->read(path_init + "X0");
                 initV->read(path_init + "V0");
                 initE->read(path_init + "E0");
             }
             else
             {
-                // Offline phase otherwise: Compute offsets. Save offsets if rostype = 0 OR rostype = 1.
+                // Compute (and save unless using previous mode) offsets for the current window in the offline phase
                 for (int i=0; i<tH1size; ++i)
                 {
                     (*initX)(i) = X[i];

--- a/laghos_rom.hpp
+++ b/laghos_rom.hpp
@@ -201,8 +201,8 @@ public:
             if (input.offsetType == 1 && input.window > 0)
             {
                 initX->read(path_init + "X0");
-                initE->read(path_init + "E0");
                 initV->read(path_init + "V0");
+                initE->read(path_init + "E0");
             }
             else
             {

--- a/laghos_rom.hpp
+++ b/laghos_rom.hpp
@@ -40,7 +40,7 @@ struct ROM_Options
     double t_final = 0.0; // simulation final time
     double initial_dt = 0.0; // initial timestep size
 
-    bool online = false; // if true, online phase
+    bool restore = false; // if true, restore phase
     bool staticSVD = false; // true: use StaticSVDBasisGenerator; false: use IncrementalSVDBasisGenerator
     bool useOffset = false; // if true, sample variables minus initial state as an offset
     bool RHSbasis = false; // if true, use bases for nonlinear RHS terms without mass matrix inverses applied
@@ -201,25 +201,29 @@ public:
                 initE->read(path_init + "E0");
                 initV->read(path_init + "V0");
             }
-            else if (input.offsetType <= 1)
+            else
             {
                 for (int i=0; i<tH1size; ++i)
                 {
                     (*initX)(i) = X[i];
                 }
-                initX->write(path_init + "X" + std::to_string(window));
 
                 for (int i=0; i<tH1size; ++i)
                 {
                     (*initV)(i) = V[i];
                 }
-                initV->write(path_init + "V" + std::to_string(window));
 
                 for (int i=0; i<tL2size; ++i)
                 {
                     (*initE)(i) = E[i];
                 }
-                initE->write(path_init + "E" + std::to_string(window));
+
+                if (input.offsetType <= 1)
+                {
+                    initX->write(path_init + "X" + std::to_string(window));
+                    initV->write(path_init + "V" + std::to_string(window));
+                    initE->write(path_init + "E" + std::to_string(window));
+                }
             }
         }
     }

--- a/laghos_rom.hpp
+++ b/laghos_rom.hpp
@@ -200,7 +200,7 @@ public:
                 initE->read(path_init + "E0");
                 initV->read(path_init + "V0");
             }
-            else
+            else if (input.offsetType <= 1)
             {
                 for (int i=0; i<tH1size; ++i)
                 {

--- a/laghos_rom.hpp
+++ b/laghos_rom.hpp
@@ -200,12 +200,14 @@ public:
 
             if (input.offsetType == 1 && input.window > 0)
             {
+                // Offline phase rostype 1 time window > 0: Read the initial state
                 initX->read(path_init + "X0");
                 initV->read(path_init + "V0");
                 initE->read(path_init + "E0");
             }
             else
             {
+                // Offline phase otherwise: Compute offsets. Save offsets if rostype = 0 OR rostype = 1.
                 for (int i=0; i<tH1size; ++i)
                 {
                     (*initX)(i) = X[i];

--- a/merge.cpp
+++ b/merge.cpp
@@ -17,7 +17,14 @@ void LoadSampleSets(const int rank, const double energyFraction, const int nsets
     static_svd_options.max_time_intervals = 1;
     basis_generator.reset(new CAROM::StaticSVDBasisGenerator(static_svd_options, basis_filename));
 
-    cout << "Loading snapshots for " << varName << " in time window " << window << endl;
+    if (usingWindows)
+    {
+        cout << "Loading snapshots for " << varName << " in time window " << window << endl;
+    }
+    else
+    {
+        cout << "Loading snapshots for " << varName << endl;
+    }
 
     for (int i=0; i<nsets; ++i)
     {
@@ -25,10 +32,14 @@ void LoadSampleSets(const int rank, const double energyFraction, const int nsets
         basis_generator->loadSamples(filename,"snapshot");
     }
 
-    //cout << "Saving data uploaded as a snapshot" << endl;
-    //basis_generator->writeSnapshot();
-
-    cout << "Computing SVD for " << varName << " in time window " << window << endl;
+    if (usingWindows)
+    {
+        cout << "Computing SVD for " << varName << " in time window " << window << endl;
+    }
+    else
+    {
+        cout << "Computing SVD for " << varName << endl;
+    }
     basis_generator->endSamples();  // save the basis file
 
     if (rank == 0)


### PR DESCRIPTION
This PR adds the option of using different styles of offsets in time window and implemented the choice of passing the initial state as offset in all windows. The user command option `-rostype` controls `romOptions.romOffsetType` (default 0), in both offline and online stage. 

0 -> save and load offset; interpolate in parametric case (default)
1 -> use initial state as offset
2 -> use solution from previous window as offset

In this PR, the implementation of option 0 with parametric case is not complete, in which the results produced will be same as option 2.
