### PR TITLE
librom basis generator options libROM #PR44

### DIFF
--- a/laghos_rom.hpp
+++ b/laghos_rom.hpp
@@ -95,78 +95,109 @@ public:
 
         if (input.staticSVD)
         {
-            generator_X = new CAROM::StaticSVDBasisGenerator(tH1size, max_model_dim,
+            generator_X = new CAROM::StaticSVDBasisGenerator(
+                    GenerateStaticSVDOptions(
+                      tH1size,
+                      max_model_dim
+                    ),
                     BasisFileName(VariableName::X, window, parameterID));
-            generator_V = new CAROM::StaticSVDBasisGenerator(tH1size, max_model_dim,
+            generator_V = new CAROM::StaticSVDBasisGenerator(
+                    GenerateStaticSVDOptions(
+                      tH1size,
+                      max_model_dim
+                    ),
                     BasisFileName(VariableName::V, window, parameterID));
-            generator_E = new CAROM::StaticSVDBasisGenerator(tL2size, max_model_dim,
+            generator_E = new CAROM::StaticSVDBasisGenerator(
+                    GenerateStaticSVDOptions(
+                      tL2size,
+                      max_model_dim
+                    ),
                     BasisFileName(VariableName::E, window, parameterID));
 
             if (sampleF)
             {
-                generator_Fv = new CAROM::StaticSVDBasisGenerator(tH1size, max_model_dim,
+                generator_Fv = new CAROM::StaticSVDBasisGenerator(
+                        GenerateStaticSVDOptions(
+                          tH1size,
+                          max_model_dim
+                        ),
                         BasisFileName(VariableName::Fv, window, parameterID));
-                generator_Fe = new CAROM::StaticSVDBasisGenerator(tL2size, max_model_dim,
+                generator_Fe = new CAROM::StaticSVDBasisGenerator(
+                        GenerateStaticSVDOptions(
+                          tL2size,
+                          max_model_dim
+                        ),
                         BasisFileName(VariableName::Fe, window, parameterID));
             }
         }
         else
         {
-            generator_X = new CAROM::IncrementalSVDBasisGenerator(tH1size,
-                    model_linearity_tol,
-                    false,
-                    true,
-                    max_model_dim,
-                    input.initial_dt,
-                    max_model_dim,
-                    model_sampling_tol,
-                    input.t_final,
+
+            generator_X = new CAROM::IncrementalSVDBasisGenerator(
+                    GenerateIncrementalSVDOptions(
+                      tH1size,
+                      model_linearity_tol,
+                      true,
+                      max_model_dim,
+                      input.initial_dt,
+                      max_model_dim,
+                      model_sampling_tol,
+                      input.t_final
+                    ),
                     ROMBasisName::X + std::to_string(window));
 
-            generator_V = new CAROM::IncrementalSVDBasisGenerator(tH1size,
-                    model_linearity_tol,
-                    false,
-                    true,
-                    max_model_dim,
-                    input.initial_dt,
-                    max_model_dim,
-                    model_sampling_tol,
-                    input.t_final,
+            generator_V = new CAROM::IncrementalSVDBasisGenerator(
+                    GenerateIncrementalSVDOptions(
+                      tH1size,
+                      model_linearity_tol,
+                      true,
+                      max_model_dim,
+                      input.initial_dt,
+                      max_model_dim,
+                      model_sampling_tol,
+                      input.t_final
+                    ),
                     ROMBasisName::V + std::to_string(window));
 
-            generator_E = new CAROM::IncrementalSVDBasisGenerator(tL2size,
-                    model_linearity_tol,
-                    false,
-                    true,
-                    max_model_dim,
-                    input.initial_dt,
-                    max_model_dim,
-                    model_sampling_tol,
-                    input.t_final,
+            generator_E = new CAROM::IncrementalSVDBasisGenerator(
+                    GenerateIncrementalSVDOptions(
+                      tL2size,
+                      model_linearity_tol,
+                      true,
+                      max_model_dim,
+                      input.initial_dt,
+                      max_model_dim,
+                      model_sampling_tol,
+                      input.t_final
+                    ),
                     ROMBasisName::E + std::to_string(window));
 
             if (sampleF)
             {
-                generator_Fv = new CAROM::IncrementalSVDBasisGenerator(tH1size,
-                        model_linearity_tol,
-                        false,
-                        true,
-                        max_model_dim,
-                        input.initial_dt,
-                        max_model_dim,
-                        model_sampling_tol,
-                        input.t_final,
+                generator_Fv = new CAROM::IncrementalSVDBasisGenerator(
+                        GenerateIncrementalSVDOptions(
+                          tH1size,
+                          model_linearity_tol,
+                          true,
+                          max_model_dim,
+                          input.initial_dt,
+                          max_model_dim,
+                          model_sampling_tol,
+                          input.t_final
+                        ),
                         ROMBasisName::Fv + std::to_string(window));
 
-                generator_Fe = new CAROM::IncrementalSVDBasisGenerator(tL2size,
-                        model_linearity_tol,
-                        false,
-                        true,
-                        max_model_dim,
-                        input.initial_dt,
-                        max_model_dim,
-                        model_sampling_tol,
-                        input.t_final,
+                generator_Fe = new CAROM::IncrementalSVDBasisGenerator(
+                        GenerateIncrementalSVDOptions(
+                          tL2size,
+                          model_linearity_tol,
+                          true,
+                          max_model_dim,
+                          input.initial_dt,
+                          max_model_dim,
+                          model_sampling_tol,
+                          input.t_final
+                        ),
                         ROMBasisName::Fe + std::to_string(window));
             }
         }
@@ -213,6 +244,19 @@ public:
     void SampleSolution(const double t, const double dt, Vector const& S);
 
     void Finalize(const double t, const double dt, Vector const& S, Array<int> &cutoff);
+
+    CAROM::StaticSVDOptions GenerateStaticSVDOptions(int dim, int samples_per_time_interval)
+    {
+      CAROM::StaticSVDOptions static_svd_options(dim, samples_per_time_interval);
+      return static_svd_options;
+    }
+
+    CAROM::IncrementalSVDOptions GenerateIncrementalSVDOptions(int dim, double linearity_tol, bool fast_update, int max_basis_dimension, double initial_dt, int samples_per_time_interval, double sampling_tol, double max_time_between_samples)
+    {
+      CAROM::IncrementalSVDOptions inc_svd_options(dim, linearity_tol, max_basis_dimension, initial_dt, samples_per_time_interval, sampling_tol, max_time_between_samples);
+      inc_svd_options.fast_update = fast_update;
+      return inc_svd_options;
+    }
 
     int MaxNumSamples()
     {

--- a/laghos_rom.hpp
+++ b/laghos_rom.hpp
@@ -96,78 +96,78 @@ public:
         if (input.staticSVD)
         {
             CAROM::StaticSVDOptions static_x_options(
-              tH1size,
-              max_model_dim
+                tH1size,
+                max_model_dim
             );
             CAROM::StaticSVDOptions static_e_options(
-              tL2size,
-              max_model_dim
+                tL2size,
+                max_model_dim
             );
             generator_X = new CAROM::StaticSVDBasisGenerator(
-                    static_x_options,
-                    BasisFileName(VariableName::X, window, parameterID));
+                static_x_options,
+                BasisFileName(VariableName::X, window, parameterID));
             generator_V = new CAROM::StaticSVDBasisGenerator(
-                    static_x_options,
-                    BasisFileName(VariableName::V, window, parameterID));
+                static_x_options,
+                BasisFileName(VariableName::V, window, parameterID));
             generator_E = new CAROM::StaticSVDBasisGenerator(
-                    static_e_options,
-                    BasisFileName(VariableName::E, window, parameterID));
+                static_e_options,
+                BasisFileName(VariableName::E, window, parameterID));
 
             if (sampleF)
             {
                 generator_Fv = new CAROM::StaticSVDBasisGenerator(
-                        static_x_options,
-                        BasisFileName(VariableName::Fv, window, parameterID));
+                    static_x_options,
+                    BasisFileName(VariableName::Fv, window, parameterID));
                 generator_Fe = new CAROM::StaticSVDBasisGenerator(
-                        static_e_options,
-                        BasisFileName(VariableName::Fe, window, parameterID));
+                    static_e_options,
+                    BasisFileName(VariableName::Fe, window, parameterID));
             }
         }
         else
         {
             CAROM::IncrementalSVDOptions inc_x_options(
-              tH1size,
-              max_model_dim,
-              model_linearity_tol,
-              input.initial_dt,
-              max_model_dim,
-              model_sampling_tol,
-              input.t_final,
-              false,
-              true
+                tH1size,
+                max_model_dim,
+                model_linearity_tol,
+                max_model_dim,
+                input.initial_dt,
+                model_sampling_tol,
+                input.t_final,
+                false,
+                true
             );
             CAROM::IncrementalSVDOptions inc_e_options(
-              tL2size,
-              max_model_dim,
-              model_linearity_tol,
-              input.initial_dt,
-              max_model_dim,
-              model_sampling_tol,
-              input.t_final,
-              false,
-              true
+                tL2size,
+                max_model_dim,
+                model_linearity_tol,
+                max_model_dim,
+                input.initial_dt,
+                model_sampling_tol,
+                input.t_final,
+                false,
+                true
             );
             generator_X = new CAROM::IncrementalSVDBasisGenerator(
-                    inc_x_options,
-                    ROMBasisName::X + std::to_string(window));
+                inc_x_options,
+                ROMBasisName::X + std::to_string(window));
 
             generator_V = new CAROM::IncrementalSVDBasisGenerator(
-                    inc_x_options,
-                    ROMBasisName::V + std::to_string(window));
+                inc_x_options,
+                ROMBasisName::V + std::to_string(window));
 
             generator_E = new CAROM::IncrementalSVDBasisGenerator(
-                    inc_e_options,
-                    ROMBasisName::E + std::to_string(window));
+                inc_e_options,
+                ROMBasisName::E + std::to_string(window));
 
             if (sampleF)
             {
                 generator_Fv = new CAROM::IncrementalSVDBasisGenerator(
-                        inc_x_options,
-                        ROMBasisName::Fv + std::to_string(window));
+                    inc_x_options,
+                    ROMBasisName::Fv + std::to_string(window));
 
                 generator_Fe = new CAROM::IncrementalSVDBasisGenerator(
-                        inc_e_options,
-                        ROMBasisName::Fe + std::to_string(window));
+                    inc_e_options,
+                    ROMBasisName::Fe + std::to_string(window));
             }
         }
 

--- a/laghos_rom.hpp
+++ b/laghos_rom.hpp
@@ -136,9 +136,9 @@ public:
             generator_X = new CAROM::IncrementalSVDBasisGenerator(
                     GenerateIncrementalSVDOptions(
                       tH1size,
+                      max_model_dim,
                       model_linearity_tol,
                       true,
-                      max_model_dim,
                       input.initial_dt,
                       max_model_dim,
                       model_sampling_tol,
@@ -149,9 +149,9 @@ public:
             generator_V = new CAROM::IncrementalSVDBasisGenerator(
                     GenerateIncrementalSVDOptions(
                       tH1size,
+                      max_model_dim,
                       model_linearity_tol,
                       true,
-                      max_model_dim,
                       input.initial_dt,
                       max_model_dim,
                       model_sampling_tol,
@@ -162,9 +162,9 @@ public:
             generator_E = new CAROM::IncrementalSVDBasisGenerator(
                     GenerateIncrementalSVDOptions(
                       tL2size,
+                      max_model_dim,
                       model_linearity_tol,
                       true,
-                      max_model_dim,
                       input.initial_dt,
                       max_model_dim,
                       model_sampling_tol,
@@ -177,9 +177,9 @@ public:
                 generator_Fv = new CAROM::IncrementalSVDBasisGenerator(
                         GenerateIncrementalSVDOptions(
                           tH1size,
+                          max_model_dim,
                           model_linearity_tol,
                           true,
-                          max_model_dim,
                           input.initial_dt,
                           max_model_dim,
                           model_sampling_tol,
@@ -190,9 +190,9 @@ public:
                 generator_Fe = new CAROM::IncrementalSVDBasisGenerator(
                         GenerateIncrementalSVDOptions(
                           tL2size,
+                          max_model_dim,
                           model_linearity_tol,
                           true,
-                          max_model_dim,
                           input.initial_dt,
                           max_model_dim,
                           model_sampling_tol,
@@ -251,9 +251,9 @@ public:
       return static_svd_options;
     }
 
-    CAROM::IncrementalSVDOptions GenerateIncrementalSVDOptions(int dim, double linearity_tol, bool fast_update, int max_basis_dimension, double initial_dt, int samples_per_time_interval, double sampling_tol, double max_time_between_samples)
+    CAROM::IncrementalSVDOptions GenerateIncrementalSVDOptions(int dim, int samples_per_time_interval, double linearity_tol, bool fast_update, int max_basis_dimension, double initial_dt, double sampling_tol, double max_time_between_samples)
     {
-      CAROM::IncrementalSVDOptions inc_svd_options(dim, linearity_tol, max_basis_dimension, initial_dt, samples_per_time_interval, sampling_tol, max_time_between_samples);
+      CAROM::IncrementalSVDOptions inc_svd_options(dim, samples_per_time_interval, linearity_tol, max_basis_dimension, initial_dt, sampling_tol, max_time_between_samples);
       inc_svd_options.fast_update = fast_update;
       return inc_svd_options;
     }

--- a/laghos_rom.hpp
+++ b/laghos_rom.hpp
@@ -95,109 +95,78 @@ public:
 
         if (input.staticSVD)
         {
+            CAROM::StaticSVDOptions static_x_options(
+              tH1size,
+              max_model_dim
+            );
+            CAROM::StaticSVDOptions static_e_options(
+              tL2size,
+              max_model_dim
+            );
             generator_X = new CAROM::StaticSVDBasisGenerator(
-                    GenerateStaticSVDOptions(
-                      tH1size,
-                      max_model_dim
-                    ),
+                    static_x_options,
                     BasisFileName(VariableName::X, window, parameterID));
             generator_V = new CAROM::StaticSVDBasisGenerator(
-                    GenerateStaticSVDOptions(
-                      tH1size,
-                      max_model_dim
-                    ),
+                    static_x_options,
                     BasisFileName(VariableName::V, window, parameterID));
             generator_E = new CAROM::StaticSVDBasisGenerator(
-                    GenerateStaticSVDOptions(
-                      tL2size,
-                      max_model_dim
-                    ),
+                    static_e_options,
                     BasisFileName(VariableName::E, window, parameterID));
 
             if (sampleF)
             {
                 generator_Fv = new CAROM::StaticSVDBasisGenerator(
-                        GenerateStaticSVDOptions(
-                          tH1size,
-                          max_model_dim
-                        ),
+                        static_x_options,
                         BasisFileName(VariableName::Fv, window, parameterID));
                 generator_Fe = new CAROM::StaticSVDBasisGenerator(
-                        GenerateStaticSVDOptions(
-                          tL2size,
-                          max_model_dim
-                        ),
+                        static_e_options,
                         BasisFileName(VariableName::Fe, window, parameterID));
             }
         }
         else
         {
-
+            CAROM::IncrementalSVDOptions inc_x_options(
+              tH1size,
+              max_model_dim,
+              model_linearity_tol,
+              input.initial_dt,
+              max_model_dim,
+              model_sampling_tol,
+              input.t_final,
+              false,
+              true
+            );
+            CAROM::IncrementalSVDOptions inc_e_options(
+              tL2size,
+              max_model_dim,
+              model_linearity_tol,
+              input.initial_dt,
+              max_model_dim,
+              model_sampling_tol,
+              input.t_final,
+              false,
+              true
+            );
             generator_X = new CAROM::IncrementalSVDBasisGenerator(
-                    GenerateIncrementalSVDOptions(
-                      tH1size,
-                      max_model_dim,
-                      model_linearity_tol,
-                      true,
-                      input.initial_dt,
-                      max_model_dim,
-                      model_sampling_tol,
-                      input.t_final
-                    ),
+                    inc_x_options,
                     ROMBasisName::X + std::to_string(window));
 
             generator_V = new CAROM::IncrementalSVDBasisGenerator(
-                    GenerateIncrementalSVDOptions(
-                      tH1size,
-                      max_model_dim,
-                      model_linearity_tol,
-                      true,
-                      input.initial_dt,
-                      max_model_dim,
-                      model_sampling_tol,
-                      input.t_final
-                    ),
+                    inc_x_options,
                     ROMBasisName::V + std::to_string(window));
 
             generator_E = new CAROM::IncrementalSVDBasisGenerator(
-                    GenerateIncrementalSVDOptions(
-                      tL2size,
-                      max_model_dim,
-                      model_linearity_tol,
-                      true,
-                      input.initial_dt,
-                      max_model_dim,
-                      model_sampling_tol,
-                      input.t_final
-                    ),
+                    inc_e_options,
                     ROMBasisName::E + std::to_string(window));
 
             if (sampleF)
             {
                 generator_Fv = new CAROM::IncrementalSVDBasisGenerator(
-                        GenerateIncrementalSVDOptions(
-                          tH1size,
-                          max_model_dim,
-                          model_linearity_tol,
-                          true,
-                          input.initial_dt,
-                          max_model_dim,
-                          model_sampling_tol,
-                          input.t_final
-                        ),
+                        inc_x_options,
                         ROMBasisName::Fv + std::to_string(window));
 
                 generator_Fe = new CAROM::IncrementalSVDBasisGenerator(
-                        GenerateIncrementalSVDOptions(
-                          tL2size,
-                          max_model_dim,
-                          model_linearity_tol,
-                          true,
-                          input.initial_dt,
-                          max_model_dim,
-                          model_sampling_tol,
-                          input.t_final
-                        ),
+                        inc_e_options,
                         ROMBasisName::Fe + std::to_string(window));
             }
         }
@@ -244,19 +213,6 @@ public:
     void SampleSolution(const double t, const double dt, Vector const& S);
 
     void Finalize(const double t, const double dt, Vector const& S, Array<int> &cutoff);
-
-    CAROM::StaticSVDOptions GenerateStaticSVDOptions(int dim, int samples_per_time_interval)
-    {
-      CAROM::StaticSVDOptions static_svd_options(dim, samples_per_time_interval);
-      return static_svd_options;
-    }
-
-    CAROM::IncrementalSVDOptions GenerateIncrementalSVDOptions(int dim, int samples_per_time_interval, double linearity_tol, bool fast_update, int max_basis_dimension, double initial_dt, double sampling_tol, double max_time_between_samples)
-    {
-      CAROM::IncrementalSVDOptions inc_svd_options(dim, samples_per_time_interval, linearity_tol, max_basis_dimension, initial_dt, sampling_tol, max_time_between_samples);
-      inc_svd_options.fast_update = fast_update;
-      return inc_svd_options;
-    }
 
     int MaxNumSamples()
     {

--- a/merge.cpp
+++ b/merge.cpp
@@ -57,7 +57,7 @@ void LoadSampleSets(const int rank, const double energyFraction, const int nsets
     std::unique_ptr<CAROM::SVDBasisGenerator> basis_generator;
 
     std::string basis_filename = "run/basis" + varName + std::to_string(window);
-    basis_generator.reset(new CAROM::StaticSVDBasisGenerator(dim, totalSamples, basis_filename));
+    basis_generator.reset(new CAROM::StaticSVDBasisGenerator(CAROM::StaticSVDOptions(dim, totalSamples), basis_filename));
 
     cout << "Loading snapshots for " << varName << " in time window " << window << endl;
 


### PR DESCRIPTION
Unfortunately, brace initialization is only allowed when the struct has default values in C++ 14, and designated initializer lists only exist in C++ 20.

Verified, all tests passing.