### PR TITLE
Some small bug fixes

### DIFF
--- a/laghos.cpp
+++ b/laghos.cpp
@@ -79,7 +79,7 @@ int problem;
 double rho0(const Vector &);
 void v0(const Vector &, Vector &);
 double e0(const Vector &);
-double gamma(const Vector &);
+double gamma_func(const Vector &);
 void display_banner(ostream & os);
 
 void PrintParGridFunction(const int rank, const std::string& name, ParGridFunction *gf)
@@ -678,7 +678,7 @@ int main(int argc, char *argv[])
     L2_FECollection mat_fec(0, pmesh->Dimension());
     ParFiniteElementSpace mat_fes(pmesh, &mat_fec);
     ParGridFunction mat_gf(&mat_fes);
-    FunctionCoefficient mat_coeff(gamma);
+    FunctionCoefficient mat_coeff(gamma_func);
     mat_gf.ProjectCoefficient(mat_coeff);
     GridFunctionCoefficient *mat_gf_coeff = new GridFunctionCoefficient(&mat_gf);
 
@@ -1515,7 +1515,7 @@ double rho0(const Vector &x)
     }
 }
 
-double gamma(const Vector &x)
+double gamma_func(const Vector &x)
 {
     switch (problem)
     {
@@ -1608,11 +1608,11 @@ double e0(const Vector &x)
     case 1:
         return 0.0; // This case in initialized in main().
     case 2:
-        return (x(0) < 0.5) ? 1.0 / rho0(x) / (gamma(x) - 1.0)
-               : 0.1 / rho0(x) / (gamma(x) - 1.0);
+        return (x(0) < 0.5) ? 1.0 / rho0(x) / (gamma_func(x) - 1.0)
+               : 0.1 / rho0(x) / (gamma_func(x) - 1.0);
     case 3:
-        return (x(0) > 1.0) ? 0.1 / rho0(x) / (gamma(x) - 1.0)
-               : 1.0 / rho0(x) / (gamma(x) - 1.0);
+        return (x(0) > 1.0) ? 0.1 / rho0(x) / (gamma_func(x) - 1.0)
+               : 1.0 / rho0(x) / (gamma_func(x) - 1.0);
     case 4:
     {
         const double r = rad(x(0), x(1)), rsq = x(0) * x(0) + x(1) * x(1);

--- a/laghos_rom.cpp
+++ b/laghos_rom.cpp
@@ -1074,11 +1074,11 @@ void ROM_Basis::SetupHyperreduction(ParFiniteElementSpace *H1FESpace, ParFiniteE
 
     if (!useGramSchmidt)
     {
-        ComputeReducedRHS();
+        ComputeReducedMatrices();
     }
 }
 
-void ROM_Basis::ComputeReducedRHS()
+void ROM_Basis::ComputeReducedMatrices()
 {
     if (RHSbasis && rank == 0)
     {
@@ -1973,7 +1973,7 @@ void ROM_Operator::InducedGramSchmidtInitialize(Vector &S)
 {
     InducedGramSchmidt(1, S); // velocity
     InducedGramSchmidt(2, S); // energy
-    basis->ComputeReducedRHS();
+    basis->ComputeReducedMatrices();
     if (useReducedMv)
     {
         ComputeReducedMv();
@@ -1990,12 +1990,6 @@ void ROM_Operator::InducedGramSchmidtFinalize(Vector &S)
 {
     UndoInducedGramSchmidt(1, S); // velocity
     UndoInducedGramSchmidt(2, S); // energy
-    basis->ComputeReducedRHS();
-    if (useReducedMv)
-    {
-        ComputeReducedMv();
-        ComputeReducedMe();
-    }
 
     if (hyperreduce)
     {

--- a/laghos_rom.hpp
+++ b/laghos_rom.hpp
@@ -478,7 +478,7 @@ public:
         return BEsp;
     }
 
-    void ComputeReducedRHS();
+    void ComputeReducedMatrices();
 
     MPI_Comm comm;
 


### PR DESCRIPTION
This PR fixes some minor issues.

1. A recent change to MFEM broke Laghos/master, which has been fixed by renaming the `gamma` function in laghos.cpp. That change is manually reproduced here.
2. Changing CAROM_VERIFY to CAROM_ASSERT in libROM/Master.C (many instances) revealed an inconsequential bug in ROM_Operator::InducedGramSchmidtFinalize. The function ComputeReducedRHS should not be called there, as it computes meaningless products of matrices that have inconsistent sizes. These reduced matrix products are not used after this function call, so it does not affect the computations. Also ComputeReducedM{v,e} is unnecessary here. These incorrect and unnecessary function calls are now removed.
3. The name ComputeReducedRHS has been updated to ComputeReducedMatrices (it does not compute a RHS, so this name is no longer accurate).