### PR TITLE
Interpolation of offsets in basis time windows

### DIFF
--- a/laghos.cpp
+++ b/laghos.cpp
@@ -795,8 +795,14 @@ int main(int argc, char *argv[])
             if (myid == 0)
             {
                 std::ofstream outfile_offlineParam(offlineParam_outputPath);
-                outfile_offlineParam << romOptions.useOffset << " " << romOptions.offsetType << " " << romOptions.RHSbasis << " " << numWindows << " " << twfile << endl;
-                outfile_offlineParam << romOptions.parameterID << " " <<  rhoFactor << " " << blast_energyFactor << endl;
+                outfile_offlineParam << romOptions.useOffset << " ";
+                outfile_offlineParam << romOptions.offsetType << " ";
+                outfile_offlineParam << romOptions.RHSbasis << " ";
+                outfile_offlineParam << numWindows << " ";
+                outfile_offlineParam << twfile << endl;
+                outfile_offlineParam << romOptions.parameterID << " ";
+                outfile_offlineParam << rhoFactor << " ";
+                outfile_offlineParam << blast_energyFactor << endl;
                 outfile_offlineParam.close();
             }
         }
@@ -817,7 +823,9 @@ int main(int argc, char *argv[])
             if (myid == 0)
             {
                 std::ofstream outfile_offlineParam(offlineParam_outputPath, std::fstream::app);
-                outfile_offlineParam << romOptions.parameterID << " " <<  rhoFactor << " " << blast_energyFactor << endl;
+                outfile_offlineParam << romOptions.parameterID << " ";
+                outfile_offlineParam << rhoFactor << " ";
+                outfile_offlineParam << blast_energyFactor << endl;
                 outfile_offlineParam.close();
             }
         }
@@ -865,7 +873,6 @@ int main(int argc, char *argv[])
                 }
             }
         }
-
         infile_offlineParam.close();
     }
 

--- a/laghos.cpp
+++ b/laghos.cpp
@@ -165,7 +165,6 @@ int main(int argc, char *argv[])
     const char *twpfile = "twp.csv";
     int partition_type = 0;
     double blast_energy = 0.25;
-    double blast_energyFactor = 1.0;
     double blast_position[] = {0.0, 0.0, 0.0};
     bool rom_offline = false;
     bool rom_online = false;
@@ -181,7 +180,6 @@ int main(int argc, char *argv[])
     bool writeSol = false;
     bool solDiff = false;
     bool match_end_time = false;
-    double rhoFactor = 1.0;
     const char *normtype_char = "l2";
     const char *offsetType = "previous";
     Array<double> twep;
@@ -291,8 +289,8 @@ int main(int argc, char *argv[])
                    "Sample RHS");
     args.AddOption(&romOptions.GramSchmidt, "-romgs", "--romgramschmidt", "-no-romgs", "--no-romgramschmidt",
                    "Enable or disable Gram-Schmidt orthonormalization on V and E induced by mass matrices.");
-    args.AddOption(&rhoFactor, "-rhof", "--rhofactor", "Factor for scaling rho.");
-    args.AddOption(&blast_energyFactor, "-bef", "--blastefactor", "Factor for scaling blast energy.");
+    args.AddOption(&romOptions.rhoFactor, "-rhof", "--rhofactor", "Factor for scaling rho.");
+    args.AddOption(&romOptions.blast_energyFactor, "-bef", "--blastefactor", "Factor for scaling blast energy.");
     args.AddOption(&romOptions.parameterID, "-rpar", "--romparam", "ROM offline parameter index.");
     args.AddOption(&romOptions.paramOffset, "-rparos", "--romparamoffset", "-no-rparos", "--no-romparamoffset",
                    "Enable or disable parametric offset."); // TODO: redundant, remove after PR 98 and remove in regression tests
@@ -651,7 +649,7 @@ int main(int argc, char *argv[])
     // time evolution.
     ParGridFunction rho(&L2FESpace);
     FunctionCoefficient rho_coeff0(rho0);
-    ProductCoefficient rho_coeff(rhoFactor, rho_coeff0);
+    ProductCoefficient rho_coeff(romOptions.rhoFactor, rho_coeff0);
     L2_FECollection l2_fec(order_e, pmesh->Dimension());
     ParFiniteElementSpace l2_fes(pmesh, &l2_fec);
     ParGridFunction l2_rho(&l2_fes), l2_e(&l2_fes);
@@ -661,7 +659,7 @@ int main(int argc, char *argv[])
     {
         // For the Sedov test, we use a delta function at the origin.
         DeltaCoefficient e_coeff(blast_position[0], blast_position[1],
-                                 blast_position[2], blast_energyFactor*blast_energy);
+                                 blast_position[2], romOptions.blast_energyFactor*blast_energy);
         l2_e.ProjectCoefficient(e_coeff);
     }
     else
@@ -801,8 +799,8 @@ int main(int argc, char *argv[])
                 outfile_offlineParam << numWindows << " ";
                 outfile_offlineParam << twfile << endl;
                 outfile_offlineParam << romOptions.parameterID << " ";
-                outfile_offlineParam << rhoFactor << " ";
-                outfile_offlineParam << blast_energyFactor << endl;
+                outfile_offlineParam << romOptions.rhoFactor << " ";
+                outfile_offlineParam << romOptions.blast_energyFactor << endl;
                 outfile_offlineParam.close();
             }
         }
@@ -824,8 +822,8 @@ int main(int argc, char *argv[])
             {
                 std::ofstream outfile_offlineParam(offlineParam_outputPath, std::fstream::app);
                 outfile_offlineParam << romOptions.parameterID << " ";
-                outfile_offlineParam << rhoFactor << " ";
-                outfile_offlineParam << blast_energyFactor << endl;
+                outfile_offlineParam << romOptions.rhoFactor << " ";
+                outfile_offlineParam << romOptions.blast_energyFactor << endl;
                 outfile_offlineParam.close();
             }
         }
@@ -841,38 +839,6 @@ int main(int argc, char *argv[])
         split_line(line, words);
         MFEM_VERIFY(std::stoi(words[0]) == romOptions.useOffset, "-romos option does not match record.");
         MFEM_VERIFY(std::stoi(words[1]) == romOptions.offsetType, "-romostype option does not match record.");
-
-        if (romOptions.offsetType == interpolateOffset)
-        {
-            int true_idx = -1;
-            double coeff_sum = 0.0;
-            while (std::getline(infile_offlineParam, line))
-            {
-                split_line(line, words);
-                romOptions.paramID_list.push_back(std::stoi(words[0]));
-                double coeff = 0.0;
-                coeff += (rhoFactor - atof(words[1].c_str())) * (rhoFactor - atof(words[1].c_str()));
-                coeff += (blast_energyFactor - atof(words[2].c_str())) * (blast_energyFactor - atof(words[2].c_str()));
-                if (coeff == 0.0)
-                {
-                    true_idx = romOptions.coeff_list.size();
-                }
-                coeff = 1 / sqrt(coeff);
-                coeff_sum += coeff;
-                romOptions.coeff_list.push_back(coeff);
-            }
-            for (int param=0; param<romOptions.paramID_list.size(); ++param)
-            {
-                if (true_idx >= 0)
-                {
-                    romOptions.coeff_list[param] = (param == true_idx) ? 1.0 : 0.0;
-                }
-                else
-                {
-                    romOptions.coeff_list[param] /= coeff_sum;
-                }
-            }
-        }
         infile_offlineParam.close();
     }
 

--- a/laghos.cpp
+++ b/laghos.cpp
@@ -128,11 +128,6 @@ void PrintDiffParGridFunction(NormType normtype, const int rank, const std::stri
     PrintNormsOfParGridFunctions(normtype, rank, name, &rgf, gf, true);
 }
 
-bool to_bool(std::string const& s)
-{
-    return (s != "0");
-}
-
 int main(int argc, char *argv[])
 {
     // Initialize MPI.

--- a/laghos_rom.cpp
+++ b/laghos_rom.cpp
@@ -374,7 +374,7 @@ ROM_Basis::ROM_Basis(ROM_Options const& input, Vector const& S, MPI_Comm comm_, 
             for (int i=0; i<tL2size; ++i)
                 (*initE)(i) = 0;
 
-            for (int param_off=0; param_off<input.paramID_list.size(); ++param_off)
+            for (int param_off=0; param_off<paramID_list.size(); ++param_off)
             {
                 CAROM::Vector *initX_off = 0;
                 CAROM::Vector *initV_off = 0;
@@ -384,7 +384,7 @@ ROM_Basis::ROM_Basis(ROM_Options const& input, Vector const& S, MPI_Comm comm_, 
                 initV_off = new CAROM::Vector(tH1size, true);
                 initE_off = new CAROM::Vector(tL2size, true);
 
-                int paramID_off = input.paramID_list[param_off];
+                int paramID_off = paramID_list[param_off];
                 std::string path_init_off = basename + "/ROMoffset/param" + std::to_string(paramID_off) + "_init" ; // paramID_off = 0, 1, 2, ...
 
                 initX_off->read(path_init_off + "X" + std::to_string(input.window));
@@ -392,11 +392,11 @@ ROM_Basis::ROM_Basis(ROM_Options const& input, Vector const& S, MPI_Comm comm_, 
                 initE_off->read(path_init_off + "E" + std::to_string(input.window));
 
                 for (int i=0; i<tH1size; ++i)
-                    (*initX)(i) += input.coeff_list[param_off] * (*initX_off)(i);
+                    (*initX)(i) += coeff_list[param_off] * (*initX_off)(i);
                 for (int i=0; i<tH1size; ++i)
-                    (*initV)(i) += input.coeff_list[param_off] * (*initV_off)(i);
+                    (*initV)(i) += coeff_list[param_off] * (*initV_off)(i);
                 for (int i=0; i<tL2size; ++i)
-                    (*initE)(i) += input.coeff_list[param_off] * (*initE_off)(i);
+                    (*initE)(i) += coeff_list[param_off] * (*initE_off)(i);
             }
             initX->write(path_init + "X" + std::to_string(input.window));
             initV->write(path_init + "V" + std::to_string(input.window));
@@ -462,6 +462,48 @@ ROM_Basis::ROM_Basis(ROM_Options const& input, Vector const& S, MPI_Comm comm_, 
         SetupHyperreduction(input.H1FESpace, input.L2FESpace, nH1, input.window);
         preprocessHyperreductionTymer.Stop();
         if(rank == 0) cout << "Elapsed time for hyper-reduction preprocessing: " << preprocessHyperreductionTymer.RealTime() << " sec\n";
+    }
+
+    if (input.offsetType == interpolateOffset)
+    {
+        // Calculation of coefficients of offset data using inverse distance weighting interpolation
+        std::ifstream infile_offlineParam(basename + "/offline_param.csv");
+        MFEM_VERIFY(infile_offlineParam.is_open(), "Offline parameter record file does not exist.");
+        std::string line;
+        std::vector<std::string> words;
+        std::getline(infile_offlineParam, line);
+        int true_idx = -1;
+        double coeff_sum = 0.0;
+        // Compute the distances from online parameters to each offline parameter
+        while (std::getline(infile_offlineParam, line))
+        {
+            split_line(line, words);
+            paramID_list.push_back(std::stoi(words[0]));
+            double coeff = 0.0;
+            coeff += (input.rhoFactor - atof(words[1].c_str())) * (input.rhoFactor - atof(words[1].c_str()));
+            coeff += (input.blast_energyFactor - atof(words[2].c_str())) * (input.blast_energyFactor - atof(words[2].c_str()));
+            if (coeff == 0.0)
+            {
+                true_idx = coeff_list.size();
+            }
+            coeff = 1 / sqrt(coeff);
+            coeff_sum += coeff;
+            coeff_list.push_back(coeff);
+        }
+        // Determine the coefficients with respect to the offline parameters
+        // The coefficients are inversely porportional to distances and form a convex combination of offset data
+        for (int param=0; param<paramID_list.size(); ++param)
+        {
+            if (true_idx >= 0)
+            {
+                coeff_list[param] = (param == true_idx) ? 1.0 : 0.0;
+            }
+            else
+            {
+                coeff_list[param] /= coeff_sum;
+            }
+        }
+        infile_offlineParam.close();
     }
 }
 

--- a/laghos_rom.cpp
+++ b/laghos_rom.cpp
@@ -353,9 +353,9 @@ ROM_Basis::ROM_Basis(ROM_Options const& input, Vector const& S, MPI_Comm comm_, 
         initV = new CAROM::Vector(tH1size, true);
         initE = new CAROM::Vector(tL2size, true);
 
-        std::string path_init = (input.paramOffset) ? basename + "/ROMoffset/online_param_init" : basename + "/ROMoffset/init";
+        std::string path_init = basename + "/ROMoffset/init";
 
-        if (input.restore || (input.offsetType == saveLoadOffset && !input.paramOffset))
+        if (input.restore || input.offsetType == saveLoadOffset)
         {
             // Read offsets in the restore phase or in the online phase of non-parametric save-and-load mode
             initX->read(path_init + "X" + std::to_string(input.window));
@@ -364,7 +364,7 @@ ROM_Basis::ROM_Basis(ROM_Options const& input, Vector const& S, MPI_Comm comm_, 
 
             cout << "Read init vectors X, V, E with norms " << initX->norm() << ", " << initV->norm() << ", " << initE->norm() << endl;
         }
-        else if (input.offsetType == saveLoadOffset && input.paramOffset)
+        else if (input.offsetType == interpolateOffset)
         {
             // Interpolate and save offset in the online phase of parametric save-and-load mode
             for (int i=0; i<tH1size; ++i)

--- a/laghos_rom.hpp
+++ b/laghos_rom.hpp
@@ -61,6 +61,8 @@ struct ROM_Options
 
     double t_final = 0.0; // simulation final time
     double initial_dt = 0.0; // initial timestep size
+    double rhoFactor = 1.0; // factor for scaling rho
+    double blast_energyFactor = 1.0; // factor for scaling blast energy
 
     bool restore = false; // if true, restore phase
     bool staticSVD = false; // true: use StaticSVDBasisGenerator; false: use IncrementalSVDBasisGenerator
@@ -90,8 +92,6 @@ struct ROM_Options
     bool RK2AvgSolver = false; // true if RK2Avg solver is used for time integration
     bool paramOffset = false; // TODO: redundant, remove after PR 98 used for determining offset options in the online stage, depending on parametric ROM or non-parametric
     offsetStyle offsetType = usePreviousSolution; // types of offset in time windows
-    std::vector<int> paramID_list; // list of all offline parameter IDs
-    std::vector<double> coeff_list; // list of all interpolating coefficients with respect to offline parameters
 
     bool mergeXV = false; // If true, merge bases for V and X-X0 by using SVDBasisGenerator on normalized basis vectors for V and X-X0.
 
@@ -574,6 +574,9 @@ private:
     double energyFraction_X;
 
     void SetupHyperreduction(ParFiniteElementSpace *H1FESpace, ParFiniteElementSpace *L2FESpace, Array<int>& nH1, const int window);
+
+    std::vector<int> paramID_list;
+    std::vector<double> coeff_list;
 };
 
 class ROM_Operator : public TimeDependentOperator

--- a/laghos_rom.hpp
+++ b/laghos_rom.hpp
@@ -88,6 +88,8 @@ struct ROM_Options
     bool RK2AvgSolver = false; // true if RK2Avg solver is used for time integration
     bool paramOffset = false; // used for determining offset options in the online stage, depending on parametric ROM or non-parametric
     offsetStyle offsetType = saveLoadOffset; // types of offset in time windows
+    std::vector<int> paramID_list; // list of all offline parameter IDs
+    std::vector<double> coeff_list; // list of all interpolating coefficients with respect to offline parameters
 
     bool mergeXV = false; // If true, merge bases for V and X-X0 by using SVDBasisGenerator on normalized basis vectors for V and X-X0.
 
@@ -212,8 +214,7 @@ public:
 
         if (offsetInit)
         {
-            //std::string path_init = (parameterID >= 0) ? basename + "/ROMoffset/param" + std::to_string(parameterID) + "_init" : basename + "/ROMoffset/init"; // TODO: Tony PR77
-            std::string path_init = basename + "/ROMoffset/init";
+            std::string path_init = (parameterID >= 0) ? basename + "/ROMoffset/param" + std::to_string(parameterID) + "_init" : basename + "/ROMoffset/init";
             initX = new CAROM::Vector(tH1size, true);
             initV = new CAROM::Vector(tH1size, true);
             initE = new CAROM::Vector(tL2size, true);

--- a/laghos_utils.cpp
+++ b/laghos_utils.cpp
@@ -1,5 +1,6 @@
 #include <fstream>
 #include <iostream>
+#include <sstream>
 
 #include "laghos_utils.hpp"
 
@@ -179,4 +180,14 @@ int ReadTimeWindowParameters(const int nw, std::string twfile, Array<double>& tw
     }
 
     return 0;
+}
+
+void split_line(const std::string &line, std::vector<std::string> &words)
+{
+    words.clear();
+    std::istringstream iss(line);
+    std::string new_word;
+    while (std::getline(iss, new_word, ' ')) {
+        words.push_back(new_word);
+    }
 }

--- a/laghos_utils.hpp
+++ b/laghos_utils.hpp
@@ -17,4 +17,6 @@ int ReadTimeWindows(const int nw, std::string twfile, Array<double>& twep, const
 
 int ReadTimeWindowParameters(const int nw, std::string twfile, Array<double>& twep, Array2D<int>& twparam, double sFactor[], const bool printStatus, const bool rhs);
 
+void split_line(const string &line, vector<string> &words);
+
 #endif // MFEM_LAGHOS_UTILS

--- a/merge.cpp
+++ b/merge.cpp
@@ -102,17 +102,6 @@ int main(int argc, char *argv[])
         outputPath += "/" + std::string(basename);
     }
 
-    std::ifstream infile_paramID(outputPath + "/paramID.csv");
-    MFEM_VERIFY(infile_paramID.is_open(), "Parameter record file does not exist.");
-    std::string line;
-    std::vector<std::string> words;
-    std::getline(infile_paramID, line);
-    split_line(line, words);
-    MFEM_VERIFY(std::stoi(words[2]) == rhsBasis, "-romsrhs option does not match record.");
-    MFEM_VERIFY(std::stoi(words[3]) == numWindows, "-nwin option does not match record.");
-    MFEM_VERIFY(std::strcmp(words[4].c_str(), twfile) == 0, "-tw option does not match record.");
-    infile_paramID.close();
-
     const bool usingWindows = (numWindows > 0); // TODO: Tony PR77 || windowNumSamples > 0);
     Array<double> twep;
     std::ofstream outfile_twp;
@@ -126,6 +115,17 @@ int main(int argc, char *argv[])
     else {
         numWindows = 1;
     }
+
+    std::ifstream infile_offlineParam(outputPath + "/offline_param.csv");
+    MFEM_VERIFY(infile_offlineParam.is_open(), "Parameter record file does not exist.");
+    std::string line;
+    std::vector<std::string> words;
+    std::getline(infile_offlineParam, line);
+    split_line(line, words);
+    MFEM_VERIFY(std::stoi(words[2]) == rhsBasis, "-romsrhs option does not match record.");
+    MFEM_VERIFY(std::stoi(words[3]) == numWindows, "-nwin option does not match record.");
+    MFEM_VERIFY(std::strcmp(words[4].c_str(), twfile) == 0, "-tw option does not match record.");
+    infile_offlineParam.close();
 
     Array<int> snapshotSize(nset);
     Array<int> snapshotSizeFv(nset);

--- a/merge.cpp
+++ b/merge.cpp
@@ -102,6 +102,17 @@ int main(int argc, char *argv[])
         outputPath += "/" + std::string(basename);
     }
 
+    std::ifstream infile_paramID(outputPath + "/paramID.csv");
+    MFEM_VERIFY(infile_paramID.is_open(), "Parameter record file does not exist.");
+    std::string line;
+    std::vector<std::string> words;
+    std::getline(infile_paramID, line);
+    split_line(line, words);
+    MFEM_VERIFY(std::stoi(words[2]) == rhsBasis, "-romsrhs option does not match record.");
+    MFEM_VERIFY(std::stoi(words[3]) == numWindows, "-nwin option does not match record.");
+    MFEM_VERIFY(std::strcmp(words[4].c_str(), twfile) == 0, "-tw option does not match record.");
+    infile_paramID.close();
+
     const bool usingWindows = (numWindows > 0); // TODO: Tony PR77 || windowNumSamples > 0);
     Array<double> twep;
     std::ofstream outfile_twp;

--- a/tests/gresho-vortices/gresho-vortices-mergexv.sh
+++ b/tests/gresho-vortices/gresho-vortices-mergexv.sh
@@ -2,10 +2,10 @@ NUM_PARALLEL_PROCESSORS=4
 testNames=(offline romhr restore)
 case $subTestNum in
   1)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -offline -writesol -romsvds -romos -romsrhs -romxandv
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -offline -writesol -romsvds -romos -rostype load -romsrhs -romxandv
     ;;
   2)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -online -rdimx 9 -rdimv 18 -rdime 30 -rdimfv 29 -rdimfe 33 -romhr -romgs -sfacx 10 -sfacv 15 -sface 15 -soldiff -romos -romsrhs -romxandv -efx 0.9999
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -online -rdimx 9 -rdimv 18 -rdime 30 -rdimfv 29 -rdimfe 33 -romhr -romgs -sfacx 10 -sfacv 15 -sface 15 -soldiff -romos -rostype load -romsrhs -romxandv -efx 0.9999
     ;;
   3)
     $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -restore -rdimx 9 -rdimv 18 -rdime 30 -romsrhs -romxandv -efx 0.9999

--- a/tests/gresho-vortices/gresho-vortices-rhsbasis.sh
+++ b/tests/gresho-vortices/gresho-vortices-rhsbasis.sh
@@ -2,12 +2,12 @@ NUM_PARALLEL_PROCESSORS=8
 testNames=(offline romhr restore)
 case $subTestNum in
   1)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -offline -writesol -romsvds -romos -romsrhs
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -offline -writesol -romsvds -romos -rostype load -romsrhs
     ;;
   2)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -online -soldiff -romhr -romsvds -sfacx 10 -sfacv 10 -sface 10 -romos -romsrhs -romgs -rdimx 9 -rdimv 20 -rdime 30 -rdimfv 29 -rdimfe 33
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -online -soldiff -romhr -romsvds -sfacx 10 -sfacv 10 -sface 10 -romos -rostype load -romsrhs -romgs -rdimx 9 -rdimv 20 -rdime 30 -rdimfv 29 -rdimfe 33
     ;;
   3)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -restore -romos -romsrhs -rdimx 9 -rdimv 20 -rdime 30 -rdimfv 29 -rdimfe 33
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -restore -romos -rostype load -romsrhs -rdimx 9 -rdimv 20 -rdime 30 -rdimfv 29 -rdimfe 33
     ;;
 esac

--- a/tests/gresho-vortices/gresho-vortices-usevx.sh
+++ b/tests/gresho-vortices/gresho-vortices-usevx.sh
@@ -2,10 +2,10 @@ NUM_PARALLEL_PROCESSORS=4
 testNames=(offline romhr restore)
 case $subTestNum in
   1)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -offline -writesol -romsvds -romos -romsrhs -romvx -efx 0.999999
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -offline -writesol -romsvds -romos -rostype load -romsrhs -romvx -efx 0.999999
     ;;
   2)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -online -rdimx 19 -rdime 30 -rdimfv 29 -rdimfe 33 -romhr -romgs -sfacx 10 -sfacv 15 -sface 15 -soldiff -romos -romsrhs -romvx
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -online -rdimx 19 -rdime 30 -rdimfv 29 -rdimfe 33 -romhr -romgs -sfacx 10 -sfacv 15 -sface 15 -soldiff -romos -rostype load -romsrhs -romvx
     ;;
   3)
     $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -restore -rdimx 19 -rdime 30 -romsrhs -romvx

--- a/tests/gresho-vortices/gresho-vortices-usexv.sh
+++ b/tests/gresho-vortices/gresho-vortices-usexv.sh
@@ -2,10 +2,10 @@ NUM_PARALLEL_PROCESSORS=4
 testNames=(offline romhr restore)
 case $subTestNum in
   1)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -offline -writesol -romsvds -romos -romsrhs -romxv
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -offline -writesol -romsvds -romos -rostype load -romsrhs -romxv
     ;;
   2)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -online -rdimv 21 -rdime 30 -rdimfv 29 -rdimfe 33 -romhr -romgs -sfacx 10 -sfacv 15 -sface 15 -soldiff -romos -romsrhs -romxv
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -online -rdimv 21 -rdime 30 -rdimfv 29 -rdimfe 33 -romhr -romgs -sfacx 10 -sfacv 15 -sface 15 -soldiff -romos -rostype load -romsrhs -romxv
     ;;
   3)
     $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -restore -rdimv 21 -rdime 30 -romsrhs -romxv

--- a/tests/sedov-blast-merge/sedov-blast-mergexv.sh
+++ b/tests/sedov-blast-merge/sedov-blast-mergexv.sh
@@ -2,10 +2,10 @@ NUM_PARALLEL_PROCESSORS=2
 testNames=(offline romhr restore)
 case $subTestNum in
   1)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.05 -offline -ef 0.9999 -writesol -romsvds -romos -romsrhs -romxandv
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.05 -offline -ef 0.9999 -writesol -romsvds -romos -rostype load -romsrhs -romxandv
     ;;
   2)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.05 -online -romos -sfacx 10 -sfacv 10 -sface 10 -soldiff -romsrhs -romgs -romhr -rdimx 24 -rdimv 60 -rdime 20 -rdimfv 114 -rdimfe 40 -romxandv -efx 0.99999
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.05 -online -romos -rostype load -sfacx 10 -sfacv 10 -sface 10 -soldiff -romsrhs -romgs -romhr -rdimx 24 -rdimv 60 -rdime 20 -rdimfv 114 -rdimfe 40 -romxandv -efx 0.99999
     ;;
   3)
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -restore -romsrhs -rdimx 24 -rdimv 60 -rdime 20 -romxandv -efx 0.99999

--- a/tests/sedov-blast-merge/sedov-blast-usevx.sh
+++ b/tests/sedov-blast-merge/sedov-blast-usevx.sh
@@ -2,10 +2,10 @@ NUM_PARALLEL_PROCESSORS=2
 testNames=(offline romhr restore)
 case $subTestNum in
   1)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.05 -offline -ef 0.9999 -writesol -romsvds -romos -romsrhs -romvx -efx 0.999999
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.05 -offline -ef 0.9999 -writesol -romsvds -romos -rostype load -romsrhs -romvx -efx 0.999999
     ;;
   2)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.05 -online -romsvds -romos -sfacx 10 -sfacv 10 -sface 10 -soldiff -romsrhs -romgs -romhr -rdimx 66 -rdime 20 -rdimfv 114 -rdimfe 40 -romvx
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.05 -online -romsvds -romos -rostype load -sfacx 10 -sfacv 10 -sface 10 -soldiff -romsrhs -romgs -romhr -rdimx 66 -rdime 20 -rdimfv 114 -rdimfe 40 -romvx
     ;;
   3)
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -restore -romsrhs -rdimx 66 -rdime 20 -romvx

--- a/tests/sedov-blast-merge/sedov-blast-usexv.sh
+++ b/tests/sedov-blast-merge/sedov-blast-usexv.sh
@@ -2,10 +2,10 @@ NUM_PARALLEL_PROCESSORS=4
 testNames=(offline romhr restore)
 case $subTestNum in
   1)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.05 -offline -ef 0.9999 -writesol -romsvds -romos -romsrhs -romxv
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.05 -offline -ef 0.9999 -writesol -romsvds -romos -rostype load -romsrhs -romxv
     ;;
   2)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.05 -online -romsvds -romos -sfacx 10 -sfacv 10 -sface 10 -soldiff -romsrhs -romgs -romhr -rdimv 60 -rdime 20 -rdimfv 114 -rdimfe 40 -romxv
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.05 -online -romsvds -romos -rostype load -sfacx 10 -sfacv 10 -sface 10 -soldiff -romsrhs -romgs -romhr -rdimv 60 -rdime 20 -rdimfv 114 -rdimfe 40 -romxv
     ;;
   3)
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -restore -romsrhs -rdimv 60 -rdime 20 -romxv

--- a/tests/sedov-blast/sedov-blast-parameter-variation.sh
+++ b/tests/sedov-blast/sedov-blast-parameter-variation.sh
@@ -2,11 +2,11 @@ NUM_PARALLEL_PROCESSORS=8
 testNames=(fom online)
 case $subTestNum in
   1)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -offline -romsvds -romos -romsrhs -bef 1.0 -rpar 0
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -offline -romsvds -romos -rostype previous -romsrhs -bef 1.0 -rpar 0
     $MERGE -nset 1 -rhs
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -bef 0.5 -writesol -visit
     ;;
   2)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 7 -rdimv 12 -rdime 6 -rdimfv 15 -rdimfe 9 -romhr -romos -sfacx 1 -sfacv 32 -sface 32 -soldiff -romgs -romsrhs -bef 1.0
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 7 -rdimv 12 -rdime 6 -rdimfv 15 -rdimfe 9 -romhr -romos -rostype previous -sfacx 1 -sfacv 32 -sface 32 -soldiff -romgs -romsrhs -bef 1.0
     ;;
 esac

--- a/tests/sedov-blast/sedov-blast-time-window-rhsbasis.sh
+++ b/tests/sedov-blast/sedov-blast-time-window-rhsbasis.sh
@@ -2,13 +2,13 @@ NUM_PARALLEL_PROCESSORS=4
 testNames=(offline online romhr restore)
 case $subTestNum in
   1)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.05 -offline -ef 0.9999 -writesol -romsvds -romos -romsrhs -nwinsamp 60
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.05 -offline -ef 0.9999 -writesol -romsvds -romos -rostype load -romsrhs -nwinsamp 60
     ;;
   2)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.05 -online -romsvds -romos -sfacx 10 -sfacv 10 -sface 10 -soldiff -romsrhs -nwin 2 -twp twpTemp.csv -romgs
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.05 -online -romsvds -romos -rostype load -sfacx 10 -sfacv 10 -sface 10 -soldiff -romsrhs -nwin 2 -twp twpTemp.csv -romgs
     ;;
   3)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.05 -online -romsvds -romos -sfacx 10 -sfacv 10 -sface 10 -soldiff -romsrhs -nwin 2 -twp twpTemp.csv -romgs -romhr
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.05 -online -romsvds -romos -rostype load -sfacx 10 -sfacv 10 -sface 10 -soldiff -romsrhs -nwin 2 -twp twpTemp.csv -romgs -romhr
     ;;
   4)
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -restore -nwin 2 -twp twpTemp.csv -romsrhs


### PR DESCRIPTION
This PR introduces a new style of offsets by interpolation (`-rostype interpolate`) in the parametric ROM setting. There are in total 4 styles of offsets, which can be specified by `-rostype previous`, `-rostype initial`, `-rostype load` and `-rostype interpolate`, where the option `-rparos` becomes redundant in this PR.  In the main file, the default value of `romOptions.offsetType` is now `usePreviousSolution`. 

In the offline phase, we run 
`srun -n 1 -p pdebug laghos -m data/cube01_hex.mesh -pt 211 -tf 0.1 -offline -romsvds -romos -rostype interpolate -romsrhs -bef 1.0 -rpar 0 -nwin 2 -tw tw2.csv`
`srun -n 1 -p pdebug laghos -m data/cube01_hex.mesh -pt 211 -tf 0.1 -offline -romsvds -romos -rostype interpolate -romsrhs -bef 1.5 -rpar 1 -nwin 2 -tw tw2.csv`
`srun -n 1 -p pdebug laghos -m data/cube01_hex.mesh -pt 211 -tf 0.1 -offline -romsvds -romos -rostype interpolate -romsrhs -bef 0.5 -rpar 2 -nwin 2 -tw tw2.csv`

The snapshots are then merged by 
`./merge -nset 3 -ef 0.9999 -rhs -nwin 2 -tw tw2.csv`

A reference solution is given by the full-order model by running
`srun -n 1 -p pdebug laghos -m data/cube01_hex.mesh -pt 211 -tf 0.1 -bef 0.5 -writesol -visit`

Then in the online phase, we run 
`srun -n 1 -p pdebug laghos -m data/cube01_hex.mesh -pt 211 -tf 0.1 -online -romhr -romos -rostype interpolate -sfacx 1 -sfacv 32 -sface 32 -soldiff -romgs -romsrhs -bef 0.5 -nwin 2 -tw tw2.csv -twp twpTemp.csv`


