### PR TITLE
Added internal energy calculation for partial assembly

### DIFF
--- a/laghos.cpp
+++ b/laghos.cpp
@@ -815,11 +815,8 @@ int main(int argc, char *argv[])
    if (mpi.Root())
    {
       cout << endl;
-      if (!p_assembly)
-      {
-         cout << "Energy  diff: " << std::scientific << std::setprecision(2)
-              << fabs(energy_init - energy_final) << endl;
-      }
+      cout << "Energy  diff: " << std::scientific << std::setprecision(2)
+           << fabs(energy_init - energy_final) << endl;
       if (mem_usage)
       {
          cout << "Maximum memory resident set size: "

--- a/laghos.cpp
+++ b/laghos.cpp
@@ -605,7 +605,27 @@ int main(int argc, char *argv[])
    BlockVector S_old(S);
    long mem=0, mmax=0, msum=0;
    int checks = 0;
-
+   const double internal_energy = hydro.InternalEnergy(e_gf);
+   const double kinetic_energy = hydro.KineticEnergy(v_gf);
+   if (mpi.Root())
+   {
+      cout << std::fixed;
+      cout << "step " << std::setw(5) << 0
+            << ",\tt = " << std::setw(5) << std::setprecision(4) << t
+            << ",\tdt = " << std::setw(5) << std::setprecision(6) << dt
+            << ",\t|IE| = " << std::setprecision(10) << std::scientific
+            << internal_energy
+            << ",\t|KE| = " << std::setprecision(10) << std::scientific
+            << kinetic_energy
+            << ",\t|E| = " << std::setprecision(10) << std::scientific
+            << kinetic_energy+internal_energy;
+      cout << std::fixed;
+      if (mem_usage)
+      {
+         cout << ", mem: " << mmax << "/" << msum << " MB";
+      }
+      cout << endl;
+   }
    for (int ti = 1; !last_step; ti++)
    {
       if (t + dt >= t_final)
@@ -664,6 +684,7 @@ int main(int argc, char *argv[])
             MPI_Reduce(&mem, &msum, 1, MPI_LONG, MPI_SUM, 0, pmesh->GetComm());
          }
          const double internal_energy = hydro.InternalEnergy(e_gf);
+         const double kinetic_energy = hydro.KineticEnergy(v_gf);
          if (mpi.Root())
          {
             const double sqrt_norm = sqrt(norm);
@@ -672,10 +693,12 @@ int main(int argc, char *argv[])
             cout << "step " << std::setw(5) << ti
                  << ",\tt = " << std::setw(5) << std::setprecision(4) << t
                  << ",\tdt = " << std::setw(5) << std::setprecision(6) << dt
-                 << ",\t|e| = " << std::setprecision(10) << std::scientific
-                 << sqrt_norm
                  << ",\t|IE| = " << std::setprecision(10) << std::scientific
-                 << internal_energy;
+                 << internal_energy
+                  << ",\t|KE| = " << std::setprecision(10) << std::scientific
+                 << kinetic_energy
+                  << ",\t|E| = " << std::setprecision(10) << std::scientific
+                 << kinetic_energy+internal_energy;
             cout << std::fixed;
             if (mem_usage)
             {

--- a/laghos.cpp
+++ b/laghos.cpp
@@ -663,15 +663,19 @@ int main(int argc, char *argv[])
             MPI_Reduce(&mem, &mmax, 1, MPI_LONG, MPI_MAX, 0, pmesh->GetComm());
             MPI_Reduce(&mem, &msum, 1, MPI_LONG, MPI_SUM, 0, pmesh->GetComm());
          }
+         const double internal_energy = hydro.InternalEnergy(e_gf);
          if (mpi.Root())
          {
             const double sqrt_norm = sqrt(norm);
+
             cout << std::fixed;
             cout << "step " << std::setw(5) << ti
                  << ",\tt = " << std::setw(5) << std::setprecision(4) << t
                  << ",\tdt = " << std::setw(5) << std::setprecision(6) << dt
                  << ",\t|e| = " << std::setprecision(10) << std::scientific
-                 << sqrt_norm;
+                 << sqrt_norm
+                 << ",\t|IE| = " << std::setprecision(10) << std::scientific
+                 << internal_energy;
             cout << std::fixed;
             if (mem_usage)
             {

--- a/laghos.cpp
+++ b/laghos.cpp
@@ -605,27 +605,27 @@ int main(int argc, char *argv[])
    BlockVector S_old(S);
    long mem=0, mmax=0, msum=0;
    int checks = 0;
-   const double internal_energy = hydro.InternalEnergy(e_gf);
-   const double kinetic_energy = hydro.KineticEnergy(v_gf);
-   if (mpi.Root())
-   {
-      cout << std::fixed;
-      cout << "step " << std::setw(5) << 0
-            << ",\tt = " << std::setw(5) << std::setprecision(4) << t
-            << ",\tdt = " << std::setw(5) << std::setprecision(6) << dt
-            << ",\t|IE| = " << std::setprecision(10) << std::scientific
-            << internal_energy
-            << ",\t|KE| = " << std::setprecision(10) << std::scientific
-            << kinetic_energy
-            << ",\t|E| = " << std::setprecision(10) << std::scientific
-            << kinetic_energy+internal_energy;
-      cout << std::fixed;
-      if (mem_usage)
-      {
-         cout << ", mem: " << mmax << "/" << msum << " MB";
-      }
-      cout << endl;
-   }
+//   const double internal_energy = hydro.InternalEnergy(e_gf);
+//   const double kinetic_energy = hydro.KineticEnergy(v_gf);
+//   if (mpi.Root())
+//   {
+//      cout << std::fixed;
+//      cout << "step " << std::setw(5) << 0
+//            << ",\tt = " << std::setw(5) << std::setprecision(4) << t
+//            << ",\tdt = " << std::setw(5) << std::setprecision(6) << dt
+//            << ",\t|IE| = " << std::setprecision(10) << std::scientific
+//            << internal_energy
+//            << ",\t|KE| = " << std::setprecision(10) << std::scientific
+//            << kinetic_energy
+//            << ",\t|E| = " << std::setprecision(10) << std::scientific
+//            << kinetic_energy+internal_energy;
+//      cout << std::fixed;
+//      if (mem_usage)
+//      {
+//         cout << ", mem: " << mmax << "/" << msum << " MB";
+//      }
+//      cout << endl;
+//   }
    for (int ti = 1; !last_step; ti++)
    {
       if (t + dt >= t_final)
@@ -683,8 +683,8 @@ int main(int argc, char *argv[])
             MPI_Reduce(&mem, &mmax, 1, MPI_LONG, MPI_MAX, 0, pmesh->GetComm());
             MPI_Reduce(&mem, &msum, 1, MPI_LONG, MPI_SUM, 0, pmesh->GetComm());
          }
-         const double internal_energy = hydro.InternalEnergy(e_gf);
-         const double kinetic_energy = hydro.KineticEnergy(v_gf);
+         // const double internal_energy = hydro.InternalEnergy(e_gf);
+         // const double kinetic_energy = hydro.KineticEnergy(v_gf);
          if (mpi.Root())
          {
             const double sqrt_norm = sqrt(norm);
@@ -693,12 +693,14 @@ int main(int argc, char *argv[])
             cout << "step " << std::setw(5) << ti
                  << ",\tt = " << std::setw(5) << std::setprecision(4) << t
                  << ",\tdt = " << std::setw(5) << std::setprecision(6) << dt
-                 << ",\t|IE| = " << std::setprecision(10) << std::scientific
-                 << internal_energy
-                  << ",\t|KE| = " << std::setprecision(10) << std::scientific
-                 << kinetic_energy
-                  << ",\t|E| = " << std::setprecision(10) << std::scientific
-                 << kinetic_energy+internal_energy;
+                 << ",\t|e| = " << std::setprecision(10) << std::scientific
+                 << sqrt_norm;
+                 //  << ",\t|IE| = " << std::setprecision(10) << std::scientific
+                 //  << internal_energy
+                 //   << ",\t|KE| = " << std::setprecision(10) << std::scientific
+                 //  << kinetic_energy
+                 //   << ",\t|E| = " << std::setprecision(10) << std::scientific
+                 //  << kinetic_energy+internal_energy;
             cout << std::fixed;
             if (mem_usage)
             {

--- a/laghos_solver.cpp
+++ b/laghos_solver.cpp
@@ -635,7 +635,8 @@ double LagrangianHydroOperator::InternalEnergy(const ParGridFunction &gf) const
     l2_interpolator->SetOutputLayout(QVectorLayout::byVDIM);
     auto L2r = L2.GetElementRestriction(ElementDofOrdering::LEXICOGRAPHIC);
     const int NQ = ir.GetNPoints(); 
-   Vector e_vector(NE*NQ), eintQ(NE*NQ);
+    const int ND = L2.GetFE(0)->GetDof();
+   Vector e_vector(NE*ND), eintQ(NE*NQ);
 
     // Get internal energy at the quadrature points
     L2r->Mult(gf, e_vector);
@@ -657,7 +658,8 @@ double LagrangianHydroOperator::KineticEnergy(const ParGridFunction &v) const
     h1_interpolator->SetOutputLayout(QVectorLayout::byVDIM);
     auto H1r = H1.GetElementRestriction(ElementDofOrdering::LEXICOGRAPHIC);
     const int NQ = ir.GetNPoints(); 
-   Vector e_vector(dim*NE*NQ), ekinQ(dim*NE*NQ);
+    const int ND = H1.GetFE(0)->GetDof();
+   Vector e_vector(dim*NE*ND), ekinQ(dim*NE*NQ);
 
     // Get internal energy at the quadrature points
     H1r->Mult(v, e_vector);

--- a/laghos_solver.cpp
+++ b/laghos_solver.cpp
@@ -564,6 +564,68 @@ void LagrangianHydroOperator::ComputeDensity(ParGridFunction &rho) const
 }
 
 
+
+double ComputeVolumeIntegral(const int DIM, const int NE,const int NQ,const int Q1D,const int VDIM,const double ln_norm,
+const mfem::Vector& mass, const mfem::Vector& f)
+{
+    
+    auto f_vals = mfem::Reshape(f.Read(),VDIM,NQ, NE);
+    mfem::Vector integrand(NE*NQ); 
+    auto I = Reshape(integrand.Write(), NQ, NE);
+
+   if (DIM == 1){
+      for (int e=0; e < NE; ++e){
+         for (int q = 0; q < NQ; ++q) {
+               double vmag = 0; 
+               for(int k = 0; k < VDIM; k++){
+                  vmag += pow(f_vals(k,q,e),ln_norm);
+               }
+               I(q,e) = vmag;
+         }
+      }
+   }
+   else if (DIM == 2){
+      MFEM_FORALL_2D(e, NE, Q1D, Q1D, 1,
+      {
+         MFEM_FOREACH_THREAD(qy,y,Q1D)
+         {
+            MFEM_FOREACH_THREAD(qx,x,Q1D)
+            {
+               const int q = qx + qy * Q1D;
+               double vmag = 0; 
+               for(int k = 0; k < VDIM; k++){
+                  vmag += pow(f_vals(k,q,e),ln_norm);
+               }
+               I(q,e) = vmag;
+            }
+         }
+      });
+   }
+   else if (DIM == 3){
+    MFEM_FORALL_3D(e, NE, Q1D, Q1D, Q1D,
+      {
+         MFEM_FOREACH_THREAD(qz,z,Q1D)
+         {
+            MFEM_FOREACH_THREAD(qy,y,Q1D)
+            {
+               MFEM_FOREACH_THREAD(qx,x,Q1D)
+               {
+                  const int q = qx + (qy + qz * Q1D) * Q1D;
+                  double vmag = 0; 
+               for(int k = 0; k < VDIM; k++){
+                  vmag += pow(f_vals(k,q,e),ln_norm);
+               }
+               I(q,e) = vmag;
+               }
+            }
+         }
+      });
+   
+}
+   const double integral = integrand * mass;
+return integral; 
+
+}
 double LagrangianHydroOperator::InternalEnergy(const ParGridFunction &gf) const
 {
    double glob_ie = 0.0;
@@ -579,19 +641,8 @@ double LagrangianHydroOperator::InternalEnergy(const ParGridFunction &gf) const
     L2r->Mult(gf, e_vector);
     l2_interpolator->Values(e_vector, eintQ);
 
-    // Get the IE, initial weighted mass 
-    auto ie_vals = mfem::Reshape(eintQ.Read(),NQ, NE);
-    auto initial_mass = mfem::Reshape(qdata.rho0DetJ0w.Read(),NQ, NE);
-
-
-    double internal_energy = 0;
-    for (int e = 0; e < NE; ++e) {
-        for (int q = 0; q < NQ; ++q) {
-            
-            internal_energy += initial_mass(q,e)*ie_vals(q,e);
-
-        }
-    }
+   double internal_energy = ComputeVolumeIntegral(dim,NE,NQ,Q1D,1,1.0,qdata.rho0DetJ0w,eintQ); 
+    
    MPI_Allreduce(&internal_energy, &glob_ie, 1, MPI_DOUBLE, MPI_SUM, L2.GetParMesh()->GetComm());
 
    return glob_ie;
@@ -599,15 +650,26 @@ double LagrangianHydroOperator::InternalEnergy(const ParGridFunction &gf) const
 
 double LagrangianHydroOperator::KineticEnergy(const ParGridFunction &v) const
 {
-   double glob_ke = 0.0;
-   // This should be turned into a kernel so that it could be displayed in pa
-   if (!p_assembly)
-   {
-      double loc_ke = 0.5 * Mv_spmat_copy.InnerProduct(v, v);
-      MPI_Allreduce(&loc_ke, &glob_ke, 1, MPI_DOUBLE, MPI_SUM,
-                    H1.GetParMesh()->GetComm());
-   }
-   return glob_ke;
+  double glob_ke = 0.0;
+   
+    // get the restriction and interpolator objects 
+    const QuadratureInterpolator* h1_interpolator = H1.GetQuadratureInterpolator(ir);
+    h1_interpolator->SetOutputLayout(QVectorLayout::byVDIM);
+    auto H1r = H1.GetElementRestriction(ElementDofOrdering::LEXICOGRAPHIC);
+    const int NQ = ir.GetNPoints(); 
+   Vector e_vector(dim*NE*NQ), ekinQ(dim*NE*NQ);
+
+    // Get internal energy at the quadrature points
+    H1r->Mult(v, e_vector);
+    h1_interpolator->Values(e_vector, ekinQ);
+
+    // Get the IE, initial weighted mass 
+
+   double kinetic_energy = ComputeVolumeIntegral(dim,NE,NQ,Q1D,dim,2.0,qdata.rho0DetJ0w,ekinQ); 
+    
+   MPI_Allreduce(&kinetic_energy, &glob_ke, 1, MPI_DOUBLE, MPI_SUM, H1.GetParMesh()->GetComm());
+
+   return 0.5*glob_ke;
 }
 
 void LagrangianHydroOperator::PrintTimingData(bool IamRoot, int steps,

--- a/makefile
+++ b/makefile
@@ -203,19 +203,19 @@ tests:
 	cat << EOF > RESULTS.dat
 	$(MFEM_MPIEXEC) $(MFEM_MPIEXEC_NP) $(MFEM_MPI_NP) \
 	./laghos -p 0 -dim 2 -rs 3 -tf 0.75 -pa -vs 100 | tee RUN.dat
-	cat RUN.dat | tail -n 20 | head -n 1 | \
+	cat RUN.dat | tail -n 21 | head -n 1 | \
 	awk '{ printf("step = %04d, dt = %s |e| = %.10e\n", $$2, $$8, $$11); }' >> RESULTS.dat
 	$(MFEM_MPIEXEC) $(MFEM_MPIEXEC_NP) $(MFEM_MPI_NP) \
 	./laghos -p 0 -dim 3 -rs 1 -tf 0.75 -pa -vs 100 | tee RUN.dat
-	cat RUN.dat | tail -n 20 | head -n 1 | \
+	cat RUN.dat | tail -n 21 | head -n 1 | \
 	awk '{ printf("step = %04d, dt = %s |e| = %.10e\n", $$2, $$8, $$11); }' >> RESULTS.dat
 	$(MFEM_MPIEXEC) $(MFEM_MPIEXEC_NP) $(MFEM_MPI_NP) \
 	./laghos -p 1 -dim 2 -rs 3 -tf 0.8 -pa -vs 100 | tee RUN.dat
-	cat RUN.dat | tail -n 17 | head -n 1 | \
+	cat RUN.dat | tail -n 18 | head -n 1 | \
 	awk '{ printf("step = %04d, dt = %s |e| = %.10e\n", $$2, $$8, $$11); }' >> RESULTS.dat
 	$(MFEM_MPIEXEC) $(MFEM_MPIEXEC_NP) $(MFEM_MPI_NP) \
 	./laghos -p 1 -dim 3 -rs 2 -tf 0.6 -pa -vs 100 | tee RUN.dat
-	cat RUN.dat | tail -n 17 | head -n 1 | \
+	cat RUN.dat | tail -n 18 | head -n 1 | \
 	awk '{ printf("step = %04d, dt = %s |e| = %.10e\n", $$2, $$8, $$11); }' >> RESULTS.dat
 	$(MFEM_MPIEXEC) $(MFEM_MPIEXEC_NP) $(MFEM_MPI_NP) \
 	./laghos -p 2 -dim 1 -rs 5 -tf 0.2 -fa -vs 100 | tee RUN.dat
@@ -223,16 +223,16 @@ tests:
 	awk '{ printf("step = %04d, dt = %s |e| = %.10e\n", $$2, $$8, $$11); }' >> RESULTS.dat
 	$(MFEM_MPIEXEC) $(MFEM_MPIEXEC_NP) $(MFEM_MPI_NP) \
 	./laghos -p 3 -m data/rectangle01_quad.mesh -rs 2 -tf 3.0 -pa -vs 100 | tee RUN.dat
-	cat RUN.dat | tail -n 17 | head -n 1 | \
+	cat RUN.dat | tail -n 18 | head -n 1 | \
 	awk '{ printf("step = %04d, dt = %s |e| = %.10e\n", $$2, $$8, $$11); }' >> RESULTS.dat
 	$(MFEM_MPIEXEC) $(MFEM_MPIEXEC_NP) $(MFEM_MPI_NP) \
 	./laghos -p 3 -m data/box01_hex.mesh -rs 1 -tf 3.0 -pa -vs 100 | tee RUN.dat
-	cat RUN.dat | tail -n 17 | head -n 1 | \
+	cat RUN.dat | tail -n 18 | head -n 1 | \
 	awk '{ printf("step = %04d, dt = %s |e| = %.10e\n", $$2, $$8, $$11); }' >> RESULTS.dat
 	$(MFEM_MPIEXEC) $(MFEM_MPIEXEC_NP) $(MFEM_MPI_NP) \
 	./laghos -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 \
 	         -ot 2 -tf 0.62831853 -s 7 -pa -vs 100 | tee RUN.dat
-	cat RUN.dat | tail -n 20 | head -n 1 | \
+	cat RUN.dat | tail -n 21 | head -n 1 | \
 	awk '{ printf("step = %04d, dt = %s |e| = %.10e\n", $$2, $$8, $$11); }' >> RESULTS.dat
 	$(shell cat << EOF > BASELINE.dat)
 	$(shell echo 'step = 0339, dt = 0.000702, |e| = 4.9695537349e+01' >> BASELINE.dat)

--- a/serial/laghos.cpp
+++ b/serial/laghos.cpp
@@ -59,7 +59,7 @@ static int problem;
 // Forward declarations.
 double e0(const Vector &);
 double rho0(const Vector &);
-double gamma(const Vector &);
+double gamma_func(const Vector &);
 void v0(const Vector &, Vector &);
 
 static long GetMaxRssMB();
@@ -333,7 +333,7 @@ int main(int argc, char *argv[])
    L2_FECollection mat_fec(0, mesh->Dimension());
    FiniteElementSpace mat_fes(mesh, &mat_fec);
    GridFunction mat_gf(&mat_fes);
-   FunctionCoefficient mat_coeff(gamma);
+   FunctionCoefficient mat_coeff(gamma_func);
    mat_gf.ProjectCoefficient(mat_coeff);
 
    // Additional details, depending on the problem.
@@ -629,7 +629,7 @@ double rho0(const Vector &x)
    }
 }
 
-double gamma(const Vector &x)
+double gamma_func(const Vector &x)
 {
    switch (problem)
    {
@@ -725,10 +725,10 @@ double e0(const Vector &x)
          return val/denom;
       }
       case 1: return 0.0; // This case in initialized in main().
-      case 2: return (x(0) < 0.5) ? 1.0 / rho0(x) / (gamma(x) - 1.0)
-                        : 0.1 / rho0(x) / (gamma(x) - 1.0);
-      case 3: return (x(0) > 1.0) ? 0.1 / rho0(x) / (gamma(x) - 1.0)
-                        : 1.0 / rho0(x) / (gamma(x) - 1.0);
+      case 2: return (x(0) < 0.5) ? 1.0 / rho0(x) / (gamma_func(x) - 1.0)
+                        : 0.1 / rho0(x) / (gamma_func(x) - 1.0);
+      case 3: return (x(0) > 1.0) ? 0.1 / rho0(x) / (gamma_func(x) - 1.0)
+                        : 1.0 / rho0(x) / (gamma_func(x) - 1.0);
       case 4:
       {
          const double r = rad(x(0), x(1)), rsq = x(0) * x(0) + x(1) * x(1);
@@ -747,7 +747,7 @@ double e0(const Vector &x)
       }
       case 5:
       {
-         const double irg = 1.0 / rho0(x) / (gamma(x) - 1.0);
+         const double irg = 1.0 / rho0(x) / (gamma_func(x) - 1.0);
          if (x(0) >= 0.5 && x(1) >= 0.5) { return 0.4 * irg; }
          if (x(0) <  0.5 && x(1) >= 0.5) { return 1.0 * irg; }
          if (x(0) <  0.5 && x(1) <  0.5) { return 1.0 * irg; }
@@ -757,7 +757,7 @@ double e0(const Vector &x)
       }
       case 6:
       {
-         const double irg = 1.0 / rho0(x) / (gamma(x) - 1.0);
+         const double irg = 1.0 / rho0(x) / (gamma_func(x) - 1.0);
          if (x(0) >= 0.5 && x(1) >= 0.5) { return 1.0 * irg; }
          if (x(0) <  0.5 && x(1) >= 0.5) { return 1.0 * irg; }
          if (x(0) <  0.5 && x(1) <  0.5) { return 1.0 * irg; }

--- a/serial/laghos_solver.cpp
+++ b/serial/laghos_solver.cpp
@@ -718,7 +718,8 @@ void LagrangianHydroOperator::UpdateQuadratureData(const Vector &S) const
             const double detJ = Jpr_b[z](q).Det();
             min_detJ = fmin(min_detJ, detJ);
             const int idx = z * nqp + q;
-            gamma_b[idx] = gamma_coeff.Eval(*T, ip);
+            // Assuming piecewise constant gamma that moves with the mesh.
+            gamma_b[idx] = gamma_gf(z_id);
             rho_b[idx] = qdata.rho0DetJ0w(z_id*nqp + q) / detJ / ip.weight;
             e_b[idx] = fmax(0.0, e_vals(q));
          }


### PR DESCRIPTION
Hi,

I noticed that the total internal energy calculation was only enabled for full assembly. I thought it might be (and found it) useful to have it in PA as well, so I made the following edits. If it looks good I can also add a similar one I have for kinetic energy (and therefore total energy), so the user could see how well energy is being conserved. 

- Varchas 
 