### PR TITLE
Fix Sedov Blast numsamp online regression test

### DIFF
--- a/tests/sedov-blast/sedov-blast-time-window-rhsbasis-parameter-variation-numsamp.sh
+++ b/tests/sedov-blast/sedov-blast-time-window-rhsbasis-parameter-variation-numsamp.sh
@@ -6,6 +6,6 @@ case $subTestNum in
     $MERGE -nset 1 -romos -rostype previous -rhs -nwinsamp 125 -nwinover 30
     ;;
   2)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.1 -online -romhr -romos -rostype previous -sfacx 1 -sfacv 32 -sface 32 -soldiff -romgs -romsrhs -bef 1.0 -twp twpTemp.csv
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.1 -online -romhr -romos -rostype previous -sfacx 1 -sfacv 32 -sface 32 -soldiff -romgs -romsrhs -bef 1.0 -nwin 2 -twp twpTemp.csv
     ;;
 esac


### PR DESCRIPTION
The `numsamp` tests pass in this branch. 

> 13. sedov-blast-time-window-rhsbasis-parameter-variation-numsamp-fom: PASS
> 14. sedov-blast-time-window-rhsbasis-parameter-variation-numsamp-online: PASS
> 15. sedov-blast-time-window-rhsbasis-parameter-variation-numsamp-fom-parallel: PASS
> 16. sedov-blast-time-window-rhsbasis-parameter-variation-numsamp-online-parallel: PASS