### PR TITLE
CI: add Github Actions to replace Travis

### DIFF
--- a/.github/actions/install-hypre/action.yml
+++ b/.github/actions/install-hypre/action.yml
@@ -1,0 +1,27 @@
+name: install-hypre
+
+inputs:
+  hypre-url:
+    description: 'URL where to look for Hypre'
+    required: false
+    default: 'https://github.com/hypre-space/hypre/archive'
+  hypre-archive:
+    description: 'Archive to download'
+    required: true
+  hypre-dir:
+    description: 'Hypre top directory name'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Hypre
+      run: |
+        wget --no-verbose ${{ inputs.hypre-url }}/${{ inputs.hypre-archive }};
+        rm -rf ${{ inputs.hypre-dir }};
+        tar -xzf ${{ inputs.hypre-archive }};
+        cd ${{ inputs.hypre-dir }}/src;
+        ./configure --disable-fortran CC=mpicc CXX=mpic++;
+        make -j3;
+        cd ../..;
+      shell: bash

--- a/.github/actions/install-metis/action.yml
+++ b/.github/actions/install-metis/action.yml
@@ -1,0 +1,25 @@
+
+name: install-metis
+
+inputs:
+  metis-url:
+    description: 'URL where to look for Metis'
+    required: false
+    default: 'https://mfem.github.io/tpls'
+  metis-archive:
+    description: 'Archive to download'
+    required: true
+  metis-dir:
+    description: 'Metis top directory name'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Metis
+      run: |
+        wget --no-verbose ${{ inputs.metis-url }}/${{ inputs.metis-archive }};
+        rm -rf ${{ inputs.metis-dir }};
+        tar -xzf ${{ inputs.metis-archive }};
+        make -j3 -C ${{ inputs.metis-dir }}/Lib CC=mpicc OPTFLAGS="-Wno-error=implicit-function-declaration -O2";
+      shell: bash

--- a/.github/actions/install-mfem/action.yml
+++ b/.github/actions/install-mfem/action.yml
@@ -1,0 +1,24 @@
+name: install-mfem
+
+inputs:
+  mfem-url:
+    description: 'Repo url for MFEM'
+    required: false
+    default: 'https://github.com/mfem/mfem.git'
+  mfem-branch:
+    description: 'Branch to checkout'
+    required: true
+  mfem-dir:
+    description: 'MFEM top directory name'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install MFEM
+      run: |
+        git clone --single-branch --branch ${{ inputs.mfem-branch }} --depth 1 ${{ inputs.mfem-url }};
+        cd mfem;
+        make -j3 parallel;
+        make info;
+      shell: bash

--- a/.github/actions/install-mfem/action.yml
+++ b/.github/actions/install-mfem/action.yml
@@ -19,7 +19,6 @@ runs:
       run: |
         git clone --single-branch --branch ${{ inputs.mfem-branch }} --depth 1 ${{ inputs.mfem-repo }};
         cd mfem;
-        make config MFEM_MPI_NP=2
-        make -j3 parallel;
+        make -j3 parallel MFEM_MPI_NP=2;
         make info;
       shell: bash

--- a/.github/actions/install-mfem/action.yml
+++ b/.github/actions/install-mfem/action.yml
@@ -19,6 +19,7 @@ runs:
       run: |
         git clone --single-branch --branch ${{ inputs.mfem-branch }} --depth 1 ${{ inputs.mfem-repo }};
         cd mfem;
+        make config MFEM_MPI_NP=2
         make -j3 parallel;
         make info;
       shell: bash

--- a/.github/actions/install-mfem/action.yml
+++ b/.github/actions/install-mfem/action.yml
@@ -1,7 +1,7 @@
 name: install-mfem
 
 inputs:
-  mfem-url:
+  mfem-repo:
     description: 'Repo url for MFEM'
     required: false
     default: 'https://github.com/mfem/mfem.git'
@@ -17,7 +17,7 @@ runs:
   steps:
     - name: Install MFEM
       run: |
-        git clone --single-branch --branch ${{ inputs.mfem-branch }} --depth 1 ${{ inputs.mfem-url }};
+        git clone --single-branch --branch ${{ inputs.mfem-branch }} --depth 1 ${{ inputs.mfem-repo }};
         cd mfem;
         make -j3 parallel;
         make info;

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,4 +1,4 @@
-name: build-laghos
+name: build-and-test-laghos
 
 on:
   push:
@@ -14,7 +14,7 @@ env:
   MFEM_TOP_DIR: mfem
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
 
     steps:
@@ -25,21 +25,21 @@ jobs:
       with:
         path: laghos
 
-    - name: Get MPI (Linux)
+    - name: get MPI (Linux)
       run: |
         sudo apt-get install mpich libmpich-dev
         export MAKE_CXX_FLAG="MPICXX=mpic++"
 
     # Get Hypre through cache, or install it.
     # Install will only run on cache miss.
-    - name: Cache Hypre Install
+    - name: cache Hypre install
       id: hypre-cache
       uses: actions/cache@v2
       with:
         path: ${{ env.HYPRE_TOP_DIR }}
         key: ${{ runner.os }}-build-${{ env.HYPRE_TOP_DIR }}-v1
 
-    - name: Get Hypre
+    - name: install Hypre
       if: steps.hypre-cache.outputs.cache-hit != 'true'
       uses: ./laghos/.github/actions/install-hypre
       with:
@@ -48,14 +48,14 @@ jobs:
 
     # Get Metis through cache, or install it.
     # Install will only run on cache miss.
-    - name: Cache Metis Install
+    - name: cache Metis install
       id: metis-cache
       uses: actions/cache@v2
       with:
         path: ${{ env.METIS_TOP_DIR }}
         key: ${{ runner.os }}-build-${{ env.METIS_TOP_DIR }}-v1
 
-    - name: Install Metis
+    - name: install Metis
       if: steps.metis-cache.outputs.cache-hit != 'true'
       uses: ./laghos/.github/actions/install-metis
       with:
@@ -77,14 +77,14 @@ jobs:
 
     # Get MFEM through cache, or install it.
     # Install will only run on cache miss.
-    - name: Cache MFEM Install
+    - name: cache MFEM install
       id: mfem-cache
       uses: actions/cache@v2
       with:
         path: ${{ env.MFEM_TOP_DIR }}
         key: ${{ runner.os }}-build-${{ env.MFEM_TOP_DIR }}-${{ env.MFEM_COMMIT }}-v2
 
-    - name: Install MFEM
+    - name: install MFEM
       if: steps.mfem-cache.outputs.cache-hit != 'true'
       uses: ./laghos/.github/actions/install-mfem
       with:
@@ -92,15 +92,15 @@ jobs:
         mfem-branch: ${{ env.MFEM_BRANCH }}
         mfem-dir: ${{ env.MFEM_TOP_DIR }}
 
-    - name: make
+    - name: build Laghos
       run: |
         cd laghos && make -j
-    - name: checks 1
+    - name: check Laghos 1 proc
       run: |
         cd laghos && make checks ranks=1
-    - name: checks 2
+    - name: check Laghos 2 procs
       run: |
         cd laghos && make checks ranks=2
-    - name: tests
+    - name: test Laghos
       run: |
         cd laghos && make tests

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,6 +1,9 @@
 name: build-and-test-laghos
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - master

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,7 +1,9 @@
 name: build-and-test-laghos
 
 on:
-  push:
+  pull_request:
+    branches:
+      - master
 
 env:
   HYPRE_ARCHIVE: v2.11.2.tar.gz

--- a/.github/workflows/build-laghos.yml
+++ b/.github/workflows/build-laghos.yml
@@ -101,12 +101,6 @@ jobs:
     - name: checks 2
       run: |
         cd laghos && make checks ranks=2
-    - name: 1
-      run: |
-        cd laghos && make 1
-    - name: 2
-      run: |
-        cd laghos && make 2
     - name: tests
       run: |
         cd laghos && make tests

--- a/.github/workflows/build-laghos.yml
+++ b/.github/workflows/build-laghos.yml
@@ -101,6 +101,6 @@ jobs:
     - name: checks 2
       run: |
         cd laghos && make checks ranks=2
-#    - name: tests
-#      run: |
-#        cd laghos && make tests
+    - name: tests
+      run: |
+        cd laghos && make tests

--- a/.github/workflows/build-laghos.yml
+++ b/.github/workflows/build-laghos.yml
@@ -9,6 +9,7 @@ env:
   METIS_URL: http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/OLD
   METIS_ARCHIVE: metis-4.0.3.tar.gz
   METIS_TOP_DIR: metis-4.0.3
+  MFEM_URL: https://github.com/mfem/mfem.git
   MFEM_BRANCH: master
   MFEM_TOP_DIR: mfem
 
@@ -70,6 +71,10 @@ jobs:
         echo "Metis symlink:"
         ln -s $METIS_TOP_DIR metis-4.0;
 
+    - name: MFEM master commit
+      run: |
+        export MFEM_COMMIT=$(git ls-remote --heads ${{ env.MFEM_URL }} ${{ env.MFEM_BRANCH }} | awk '{print $1;}')
+
     # Get MFEM through cache, or install it.
     # Install will only run on cache miss.
     - name: Cache MFEM Install
@@ -77,7 +82,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ env.MFEM_TOP_DIR }}
-        key: ${{ runner.os }}-build-${{ env.MFEM_TOP_DIR }}-v1
+        key: ${{ runner.os }}-build-${{ env.MFEM_TOP_DIR }}-${{ env.MFEM_COMMIT }}-v1
 
     - name: Install MFEM
       if: steps.mfem-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/build-laghos.yml
+++ b/.github/workflows/build-laghos.yml
@@ -91,10 +91,10 @@ jobs:
         cd laghos && make -j
     - name: checks 1
       run: |
-        cd laghos && make checks ranks=3
+        cd laghos && make checks ranks=1
     - name: checks 2
       run: |
-        cd laghos && make checks ranks=3
+        cd laghos && make checks ranks=2
     - name: checks 3
       run: |
         cd laghos && make checks ranks=3

--- a/.github/workflows/build-laghos.yml
+++ b/.github/workflows/build-laghos.yml
@@ -1,0 +1,105 @@
+name: build-laghos
+
+on:
+  push:
+
+env:
+  HYPRE_URL: https://computation.llnl.gov/project/linear_solvers/download
+  HYPRE_ARCHIVE: v2.11.2.tar.gz
+  HYPRE_TOP_DIR: hypre-2.11.2
+  METIS_URL: http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/OLD
+  METIS_ARCHIVE: metis-4.0.3.tar.gz
+  METIS_TOP_DIR: metis-4.0.3
+  MFEM_BRANCH: master
+  MFEM_TOP_DIR: mfem
+
+jobs:
+  build:
+    runs-on: ubunut-latest
+
+    steps:
+    # Checkout Laghos in "laghos" subdirectory. Final path: /home/runner/work/ceed/laghos/laghos
+    # Note: it must be done now to access "install-hypre", "install-metis" and "install-mfem" actions.
+    - name: checkout Laghos
+      uses: actions/checkout@v2
+      with:
+        path: laghos
+
+    - name: Get MPI (Linux)
+      run: |
+        sudo apt-get install mpich libmpich-dev
+        export MAKE_CXX_FLAG="MPICXX=mpic++"
+
+    # Get Hypre through cache, or install it.
+    # Install will only run on cache miss.
+    - name: Cache Hypre Install
+      id: hypre-cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.HYPRE_TOP_DIR }}
+        key: ${{ runner.os }}-build-${{ env.HYPRE_TOP_DIR }}-v1
+
+    - name: Get Hypre
+      if: steps.hypre-cache.outputs.cache-hit != 'true'
+      uses: ./laghos/.github/actions/install-hypre
+      with:
+        hypre-url: ${{ env.HYPRE_URL }}
+        hypre-archive: ${{ env.HYPRE_ARCHIVE }}
+        hypre-dir: ${{ env.HYPRE_TOP_DIR }}
+
+    # Get Metis through cache, or install it.
+    # Install will only run on cache miss.
+    - name: Cache Metis Install
+      id: metis-cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.METIS_TOP_DIR }}
+        key: ${{ runner.os }}-build-${{ env.METIS_TOP_DIR }}-v1
+
+    - name: Install Metis
+      if: steps.metis-cache.outputs.cache-hit != 'true'
+      uses: ./laghos/.github/actions/install-metis
+      with:
+        metis-url: ${{ env.METIS_URL }}
+        metis-archive: ${{ env.METIS_ARCHIVE }}
+        metis-dir: ${{ env.METIS_TOP_DIR }}
+
+    # make generic links to libraries for MFEM install
+    - name: configure links
+      run: |
+        echo "Hypre symlink:"
+        ln -s $HYPRE_TOP_DIR hypre;
+        echo "Metis symlink:"
+        ln -s $METIS_TOP_DIR metis-4.0;
+
+    # Get MFEM through cache, or install it.
+    # Install will only run on cache miss.
+    - name: Cache MFEM Install
+      id: mfem-cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.MFEM_TOP_DIR }}
+        key: ${{ runner.os }}-build-${{ env.MFEM_TOP_DIR }}-v1
+
+    - name: Install MFEM
+      if: steps.mfem-cache.outputs.cache-hit != 'true'
+      uses: ./laghos/.github/actions/install-mfem
+      with:
+        mfem-branch: ${{ env.MFEM_BRANCH }}
+        mfem-dir: ${{ env.MFEM_TOP_DIR }}
+
+    - name: make
+      run: |
+        cd laghos && make -j
+    - name: checks 1
+      run: |
+        cd laghos && make checks ranks=3
+    - name: checks 2
+      run: |
+        cd laghos && make checks ranks=3
+    - name: checks 3
+      run: |
+        cd laghos && make checks ranks=3
+    - name: tests
+      run: |
+        cd laghos && make tests

--- a/.github/workflows/build-laghos.yml
+++ b/.github/workflows/build-laghos.yml
@@ -42,7 +42,6 @@ jobs:
       if: steps.hypre-cache.outputs.cache-hit != 'true'
       uses: ./laghos/.github/actions/install-hypre
       with:
-        hypre-url: ${{ env.HYPRE_URL }}
         hypre-archive: ${{ env.HYPRE_ARCHIVE }}
         hypre-dir: ${{ env.HYPRE_TOP_DIR }}
 

--- a/.github/workflows/build-laghos.yml
+++ b/.github/workflows/build-laghos.yml
@@ -4,7 +4,6 @@ on:
   push:
 
 env:
-  HYPRE_URL: https://computation.llnl.gov/project/linear_solvers/download
   HYPRE_ARCHIVE: v2.11.2.tar.gz
   HYPRE_TOP_DIR: hypre-2.11.2
   METIS_URL: http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/OLD

--- a/.github/workflows/build-laghos.yml
+++ b/.github/workflows/build-laghos.yml
@@ -82,7 +82,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ env.MFEM_TOP_DIR }}
-        key: ${{ runner.os }}-build-${{ env.MFEM_TOP_DIR }}-${{ env.MFEM_COMMIT }}-v1
+        key: ${{ runner.os }}-build-${{ env.MFEM_TOP_DIR }}-${{ env.MFEM_COMMIT }}-v2
 
     - name: Install MFEM
       if: steps.mfem-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/build-laghos.yml
+++ b/.github/workflows/build-laghos.yml
@@ -100,9 +100,12 @@ jobs:
     - name: checks 2
       run: |
         cd laghos && make checks ranks=2
-    - name: checks 3
+    - name: 1
       run: |
-        cd laghos && make checks ranks=3
+        cd laghos && make 1
+    - name: 2
+      run: |
+        cd laghos && make 2
     - name: tests
       run: |
         cd laghos && make tests

--- a/.github/workflows/build-laghos.yml
+++ b/.github/workflows/build-laghos.yml
@@ -101,6 +101,6 @@ jobs:
     - name: checks 2
       run: |
         cd laghos && make checks ranks=2
-    - name: tests
-      run: |
-        cd laghos && make tests
+#    - name: tests
+#      run: |
+#        cd laghos && make tests

--- a/.github/workflows/build-laghos.yml
+++ b/.github/workflows/build-laghos.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubunut-latest
+    runs-on: ubuntu-latest
 
     steps:
     # Checkout Laghos in "laghos" subdirectory. Final path: /home/runner/work/ceed/laghos/laghos

--- a/.github/workflows/build-laghos.yml
+++ b/.github/workflows/build-laghos.yml
@@ -9,7 +9,7 @@ env:
   METIS_URL: http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/OLD
   METIS_ARCHIVE: metis-4.0.3.tar.gz
   METIS_TOP_DIR: metis-4.0.3
-  MFEM_URL: https://github.com/mfem/mfem.git
+  MFEM_REPO: https://github.com/mfem/mfem.git
   MFEM_BRANCH: master
   MFEM_TOP_DIR: mfem
 
@@ -73,7 +73,7 @@ jobs:
 
     - name: MFEM master commit
       run: |
-        export MFEM_COMMIT=$(git ls-remote --heads ${{ env.MFEM_URL }} ${{ env.MFEM_BRANCH }} | awk '{print $1;}')
+        echo "MFEM_COMMIT=$(git ls-remote --heads ${{ env.MFEM_REPO }} ${{ env.MFEM_BRANCH }} | awk '{print $1;}')" >> $GITHUB_ENV
 
     # Get MFEM through cache, or install it.
     # Install will only run on cache miss.
@@ -88,6 +88,7 @@ jobs:
       if: steps.mfem-cache.outputs.cache-hit != 'true'
       uses: ./laghos/.github/actions/install-mfem
       with:
+        mfem-url: ${{ env.MFEM_REPO }}
         mfem-branch: ${{ env.MFEM_BRANCH }}
         mfem-dir: ${{ env.MFEM_TOP_DIR }}
 

--- a/.github/workflows/build-laghos.yml
+++ b/.github/workflows/build-laghos.yml
@@ -88,7 +88,7 @@ jobs:
       if: steps.mfem-cache.outputs.cache-hit != 'true'
       uses: ./laghos/.github/actions/install-mfem
       with:
-        mfem-url: ${{ env.MFEM_REPO }}
+        mfem-repo: ${{ env.MFEM_REPO }}
         mfem-branch: ${{ env.MFEM_BRANCH }}
         mfem-dir: ${{ env.MFEM_TOP_DIR }}
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
         High-order Lagrangian Hydrodynamics Miniapp
 
 [![Build Status](https://travis-ci.org/CEED/Laghos.svg?branch=master)](https://travis-ci.org/CEED/Laghos)
+[![Build and Test (GH Actions)](https://github.com/CEED/Laghos/workflows/build-and-test-laghos/badge.svg?branch=master)](https://github.com/CEED/Laghos/actions?query=workflow%3Abuild-and-test-laghos)
 
 ## Purpose
 


### PR DESCRIPTION
This PR adds Github Actions, based on the work being done in MFEM (https://github.com/mfem/mfem/pull/1991)

Good:
- caching of Hypre and Metis based on archive name.
- caching of MFEM based on commit ID.

Less good:
- actions are limited in resource. Attempt to run more than 2 MPI process results in explosion of execution time.

Questions:
- [x] Travis was set up to run only on master. This is set to run on push, at least for the sake of testing this PR. Should it then be set again to run for master only?