### PR TITLE
Fix a bug in the restore phase error calculation

### DIFF
--- a/rom/laghos.cpp
+++ b/rom/laghos.cpp
@@ -1295,7 +1295,16 @@ int main(int argc, char *argv[])
                 std::string filename = outputPath + "/ROMsol/romS_" + std::to_string(ti);
                 std::ofstream outfile_romS(filename.c_str());
                 outfile_romS.precision(16);
-                romS.Print(outfile_romS, 1);
+                if (romOptions.hyperreduce && romOptions.GramSchmidt)
+                {
+                    Vector romCoord(romS);
+                    romOper[romOptions.window]->InducedGramSchmidtFinalize(romCoord, true);
+                    romCoord.Print(outfile_romS, 1);
+                }
+                else
+                {
+                    romS.Print(outfile_romS, 1);
+                }
                 outfile_romS.close();
 
                 if (!romOptions.hyperreduce)

--- a/rom/laghos_rom.cpp
+++ b/rom/laghos_rom.cpp
@@ -2204,7 +2204,7 @@ void ROM_Operator::InducedGramSchmidt(const int var, Vector &S)
     }
 }
 
-void ROM_Operator::UndoInducedGramSchmidt(const int var, Vector &S)
+void ROM_Operator::UndoInducedGramSchmidt(const int var, Vector &S, bool keep_data)
 {
     if (hyperreduce && rank == 0)
     {
@@ -2220,7 +2220,7 @@ void ROM_Operator::UndoInducedGramSchmidt(const int var, Vector &S)
             spdim = basis->SolutionSizeH1SP();
             rdim = basis->GetDimV();
             offset = basis->GetDimX();
-            X = basis->GetBVsp();
+            X = keep_data ? new CAROM::Matrix(*basis->GetBVsp()) : basis->GetBVsp();
             R = &CoordinateBVsp;
         }
         else if (var == 2) // energy
@@ -2228,7 +2228,7 @@ void ROM_Operator::UndoInducedGramSchmidt(const int var, Vector &S)
             spdim = basis->SolutionSizeL2SP();
             rdim = basis->GetDimE();
             offset = basis->GetDimX() + basis->GetDimV();
-            X = basis->GetBEsp();
+            X = keep_data ? new CAROM::Matrix(*basis->GetBEsp()) : basis->GetBEsp();
             R = &CoordinateBEsp;
         }
 
@@ -2258,8 +2258,11 @@ void ROM_Operator::UndoInducedGramSchmidt(const int var, Vector &S)
             }
             S[offset+i] /= (*R)(i,i);
         }
-        (*R).Clear();
 
+        if (keep_data)
+            delete X;
+        else
+            (*R).Clear();
     }
     else if (!hyperreduce)
     {
@@ -2284,10 +2287,10 @@ void ROM_Operator::InducedGramSchmidtInitialize(Vector &S)
     }
 }
 
-void ROM_Operator::InducedGramSchmidtFinalize(Vector &S)
+void ROM_Operator::InducedGramSchmidtFinalize(Vector &S, bool keep_data)
 {
-    UndoInducedGramSchmidt(1, S); // velocity
-    UndoInducedGramSchmidt(2, S); // energy
+    UndoInducedGramSchmidt(1, S, keep_data); // velocity
+    UndoInducedGramSchmidt(2, S, keep_data); // energy
 
     if (hyperreduce)
     {

--- a/rom/laghos_rom.hpp
+++ b/rom/laghos_rom.hpp
@@ -641,7 +641,7 @@ public:
     void StepRK2Avg(Vector &S, double &t, double &dt) const;
 
     void InducedGramSchmidtInitialize(Vector &S);
-    void InducedGramSchmidtFinalize(Vector &S);
+    void InducedGramSchmidtFinalize(Vector &S, bool keep_data=false);
 
     ~ROM_Operator()
     {
@@ -695,7 +695,7 @@ private:
     DenseMatrix CoordinateBVsp, CoordinateBEsp;
     void InducedInnerProduct(const int id1, const int id2, const int var, const int dim, double& ip);
     void InducedGramSchmidt(const int var, Vector &S);
-    void UndoInducedGramSchmidt(const int var, Vector &S);
+    void UndoInducedGramSchmidt(const int var, Vector &S, bool keep_data);
 };
 
 #endif // MFEM_LAGHOS_ROM

--- a/rom/tests/gresho-vortices/gresho-vortices-mergexv.sh
+++ b/rom/tests/gresho-vortices/gresho-vortices-mergexv.sh
@@ -5,8 +5,8 @@ case $subTestNum in
     $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -offline -writesol -romsvds -romos -rostype load -romsrhs -romxandv
     ;;
   2)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -online -rdimx 9 -rdimv 18 -rdime 30 -rdimfv 29 -rdimfe 33 -romhrprep -romgs -sfacx 10 -sfacv 15 -sface 15 -soldiff -romos -rostype load -romsrhs -romxandv -efx 0.9999
-    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -online -rdimx 9 -rdimv 18 -rdime 30 -rdimfv 29 -rdimfe 33 -romhr -romgs -sfacx 10 -sfacv 15 -sface 15 -soldiff -romos -rostype load -romsrhs -romxandv -efx 0.9999
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -online -rdimx 9 -rdimv 18 -rdime 30 -rdimfv 29 -rdimfe 33 -romhrprep -romgs -sfacx 10 -sfacv 15 -sface 15 -romos -rostype load -romsrhs -romxandv -efx 0.9999
+    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -online -rdimx 9 -rdimv 18 -rdime 30 -rdimfv 29 -rdimfe 33 -romhr -romgs -sfacx 10 -sfacv 15 -sface 15 -romos -rostype load -romsrhs -romxandv -efx 0.9999
     ;;
   3)
     $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -restore -rdimx 9 -rdimv 18 -rdime 30 -romsrhs -romxandv -efx 0.9999

--- a/rom/tests/gresho-vortices/gresho-vortices-mergexv.sh
+++ b/rom/tests/gresho-vortices/gresho-vortices-mergexv.sh
@@ -9,6 +9,6 @@ case $subTestNum in
     $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -online -rdimx 9 -rdimv 18 -rdime 30 -rdimfv 29 -rdimfe 33 -romhr -romgs -sfacx 10 -sfacv 15 -sface 15 -romos -rostype load -romsrhs -romxandv -efx 0.9999
     ;;
   3)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -restore -rdimx 9 -rdimv 18 -rdime 30 -romsrhs -romxandv -efx 0.9999
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -restore -rdimx 9 -rdimv 18 -rdime 30 -romsrhs -romxandv -efx 0.9999 -soldiff
     ;;
 esac

--- a/rom/tests/gresho-vortices/gresho-vortices-rhsbasis.sh
+++ b/rom/tests/gresho-vortices/gresho-vortices-rhsbasis.sh
@@ -5,10 +5,10 @@ case $subTestNum in
     $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -offline -writesol -romsvds -romos -rostype load -romsrhs
     ;;
   2)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -online -soldiff -romhrprep -romsvds -sfacx 10 -sfacv 10 -sface 10 -romos -rostype load -romsrhs -romgs -rdimx 9 -rdimv 20 -rdime 30 -rdimfv 29 -rdimfe 33
-    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -online -soldiff -romhr -romsvds -sfacx 10 -sfacv 10 -sface 10 -romos -rostype load -romsrhs -romgs -rdimx 9 -rdimv 20 -rdime 30 -rdimfv 29 -rdimfe 33
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -online -romhrprep -romsvds -sfacx 10 -sfacv 10 -sface 10 -romos -rostype load -romsrhs -romgs -rdimx 9 -rdimv 20 -rdime 30 -rdimfv 29 -rdimfe 33
+    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -online -romhr -romsvds -sfacx 10 -sfacv 10 -sface 10 -romos -rostype load -romsrhs -romgs -rdimx 9 -rdimv 20 -rdime 30 -rdimfv 29 -rdimfe 33
     ;;
   3)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -restore -romos -rostype load -romsrhs -rdimx 9 -rdimv 20 -rdime 30 -rdimfv 29 -rdimfe 33
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -restore -romos -rostype load -romsrhs -rdimx 9 -rdimv 20 -rdime 30 -rdimfv 29 -rdimfe 33 -soldiff
     ;;
 esac

--- a/rom/tests/gresho-vortices/gresho-vortices-time-window.sh
+++ b/rom/tests/gresho-vortices/gresho-vortices-time-window.sh
@@ -8,10 +8,10 @@ case $subTestNum in
     $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -online -soldiff -romsvds -nwin 4 -twp twpTemp.csv
     ;;
   3)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -online -soldiff -romhrprep -romsvds -sfacx 50 -sfacv 50 -sface 50 -nwin 4 -twp twpTemp.csv
-    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -online -soldiff -romhr -romsvds -sfacx 50 -sfacv 50 -sface 50 -nwin 4 -twp twpTemp.csv
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -online -romhrprep -romsvds -sfacx 50 -sfacv 50 -sface 50 -nwin 4 -twp twpTemp.csv
+    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -online -romhr -romsvds -sfacx 50 -sfacv 50 -sface 50 -nwin 4 -twp twpTemp.csv
     ;;
   4)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -restore -nwin 4 -twp twpTemp.csv
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -restore -nwin 4 -twp twpTemp.csv -soldiff
     ;;
 esac

--- a/rom/tests/gresho-vortices/gresho-vortices-usevx.sh
+++ b/rom/tests/gresho-vortices/gresho-vortices-usevx.sh
@@ -5,10 +5,10 @@ case $subTestNum in
     $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -offline -writesol -romsvds -romos -rostype load -romsrhs -romvx -efx 0.999999
     ;;
   2)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -online -rdimx 19 -rdime 30 -rdimfv 29 -rdimfe 33 -romhrprep -romgs -sfacx 10 -sfacv 15 -sface 15 -soldiff -romos -rostype load -romsrhs -romvx
-    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -online -rdimx 19 -rdime 30 -rdimfv 29 -rdimfe 33 -romhr -romgs -sfacx 10 -sfacv 15 -sface 15 -soldiff -romos -rostype load -romsrhs -romvx
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -online -rdimx 19 -rdime 30 -rdimfv 29 -rdimfe 33 -romhrprep -romgs -sfacx 10 -sfacv 15 -sface 15 -romos -rostype load -romsrhs -romvx
+    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -online -rdimx 19 -rdime 30 -rdimfv 29 -rdimfe 33 -romhr -romgs -sfacx 10 -sfacv 15 -sface 15 -romos -rostype load -romsrhs -romvx
     ;;
   3)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -restore -rdimx 19 -rdime 30 -romsrhs -romvx
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -restore -rdimx 19 -rdime 30 -romsrhs -romvx -soldiff
     ;;
 esac

--- a/rom/tests/gresho-vortices/gresho-vortices-usexv.sh
+++ b/rom/tests/gresho-vortices/gresho-vortices-usexv.sh
@@ -5,10 +5,10 @@ case $subTestNum in
     $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -offline -writesol -romsvds -romos -rostype load -romsrhs -romxv
     ;;
   2)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -online -rdimv 21 -rdime 30 -rdimfv 29 -rdimfe 33 -romhrprep -romgs -sfacx 10 -sfacv 15 -sface 15 -soldiff -romos -rostype load -romsrhs -romxv
-    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -online -rdimv 21 -rdime 30 -rdimfv 29 -rdimfe 33 -romhr -romgs -sfacx 10 -sfacv 15 -sface 15 -soldiff -romos -rostype load -romsrhs -romxv
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -online -rdimv 21 -rdime 30 -rdimfv 29 -rdimfe 33 -romhrprep -romgs -sfacx 10 -sfacv 15 -sface 15 -romos -rostype load -romsrhs -romxv
+    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -online -rdimv 21 -rdime 30 -rdimfv 29 -rdimfe 33 -romhr -romgs -sfacx 10 -sfacv 15 -sface 15 -romos -rostype load -romsrhs -romxv
     ;;
   3)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -restore -rdimv 21 -rdime 30 -romsrhs -romxv
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -restore -rdimv 21 -rdime 30 -romsrhs -romxv -soldiff
     ;;
 esac

--- a/rom/tests/gresho-vortices/gresho-vortices.sh
+++ b/rom/tests/gresho-vortices/gresho-vortices.sh
@@ -8,14 +8,14 @@ case $subTestNum in
     $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -rdimx 4 -rdimv 20 -rdime 16 -soldiff
     ;;
   3)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -rdimx 4 -rdimv 20 -rdime 16 -romhrprep -nsamx 18 -nsamv 3401 -nsame 128 -soldiff
-    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -rdimx 4 -rdimv 20 -rdime 16 -romhr -nsamx 18 -nsamv 3401 -nsame 128 -soldiff
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -rdimx 4 -rdimv 20 -rdime 16 -romhrprep -nsamx 18 -nsamv 3401 -nsame 128
+    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -rdimx 4 -rdimv 20 -rdime 16 -romhr -nsamx 18 -nsamv 3401 -nsame 128
     ;;
   4)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -rdimx 4 -rdimv 20 -rdime 16 -romhrprep -sfacv 40 -sface 40 -soldiff -qdeim
-    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -rdimx 4 -rdimv 20 -rdime 16 -romhr -sfacv 40 -sface 40 -soldiff -qdeim
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -rdimx 4 -rdimv 20 -rdime 16 -romhrprep -sfacv 40 -sface 40 -qdeim
+    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -rdimx 4 -rdimv 20 -rdime 16 -romhr -sfacv 40 -sface 40 -qdeim
     ;;
   5)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -restore -rdimx 4 -rdimv 20 -rdime 16
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -restore -rdimx 4 -rdimv 20 -rdime 16 -soldiff
     ;;
 esac

--- a/rom/tests/runRegressionTests.sh
+++ b/rom/tests/runRegressionTests.sh
@@ -540,11 +540,11 @@ do
 										continue 1
 									fi
 								elif [[ $testtype == "online" ]]; then
-									if [[ "$fileName" != *"norms.000000" ]] && [[ "$fileName" != "ROMsol" ]]; then
+									if [[ "$fileName" != "ROMsol" ]]; then
 										continue 1
 									fi
 								elif [[ $testtype == "restore" ]]; then
-									if [[ "$fileName" != *"_gf.000000" ]]; then
+									if [[ "$fileName" != *"_gf.000000" ]] && [[ "$fileName" != *"norms.000000" ]]; then
 										continue 1
 									fi
 								fi

--- a/rom/tests/sedov-blast-incremental/sedov-blast-large-tol.sh
+++ b/rom/tests/sedov-blast-incremental/sedov-blast-large-tol.sh
@@ -8,10 +8,10 @@ case $subTestNum in
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 3 -rdimv 7 -rdime 5 -nsamx 12 -nsamv 184 -nsame 30 -soldiff
     ;;
   3)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 3 -rdimv 7 -rdime 5 -romhrprep -nsamx 4 -nsamv 24 -nsame 32 -soldiff
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 3 -rdimv 7 -rdime 5 -romhr -nsamx 4 -nsamv 24 -nsame 32 -soldiff
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 3 -rdimv 7 -rdime 5 -romhrprep -nsamx 4 -nsamv 24 -nsame 32
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 3 -rdimv 7 -rdime 5 -romhr -nsamx 4 -nsamv 24 -nsame 32
     ;;
   4)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -restore -rdimx 3 -rdimv 7 -rdime 5
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -restore -rdimx 3 -rdimv 7 -rdime 5 -soldiff
     ;;
 esac

--- a/rom/tests/sedov-blast-incremental/sedov-blast-small-tol.sh
+++ b/rom/tests/sedov-blast-incremental/sedov-blast-small-tol.sh
@@ -8,10 +8,10 @@ case $subTestNum in
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 7 -rdime 5 -nsamx 12 -nsamv 184 -nsame 30 -soldiff
     ;;
   3)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 7 -rdime 5 -romhrprep -nsamx 4 -nsamv 24 -nsame 32 -soldiff
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 7 -rdime 5 -romhr -nsamx 4 -nsamv 24 -nsame 32 -soldiff
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 7 -rdime 5 -romhrprep -nsamx 4 -nsamv 24 -nsame 32
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 7 -rdime 5 -romhr -nsamx 4 -nsamv 24 -nsame 32
     ;;
   4)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -restore -rdimx 2 -rdimv 7 -rdime 5
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -restore -rdimx 2 -rdimv 7 -rdime 5 -soldiff
     ;;
 esac

--- a/rom/tests/sedov-blast-merge/sedov-blast-mergexv.sh
+++ b/rom/tests/sedov-blast-merge/sedov-blast-mergexv.sh
@@ -5,10 +5,10 @@ case $subTestNum in
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.05 -offline -ef 0.9999 -writesol -romsvds -romos -rostype load -romsrhs -romxandv
     ;;
   2)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.05 -online -romos -rostype load -sfacx 10 -sfacv 10 -sface 10 -soldiff -romsrhs -romgs -romhrprep -rdimx 24 -rdimv 60 -rdime 20 -rdimfv 110 -rdimfe 40 -romxandv -efx 0.99999
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.05 -online -romos -rostype load -sfacx 10 -sfacv 10 -sface 10 -soldiff -romsrhs -romgs -romhr -rdimx 24 -rdimv 60 -rdime 20 -rdimfv 110 -rdimfe 40 -romxandv -efx 0.99999
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.05 -online -romos -rostype load -sfacx 10 -sfacv 10 -sface 10 -romsrhs -romgs -romhrprep -rdimx 24 -rdimv 60 -rdime 20 -rdimfv 110 -rdimfe 40 -romxandv -efx 0.99999
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.05 -online -romos -rostype load -sfacx 10 -sfacv 10 -sface 10 -romsrhs -romgs -romhr -rdimx 24 -rdimv 60 -rdime 20 -rdimfv 110 -rdimfe 40 -romxandv -efx 0.99999
     ;;
   3)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -restore -romsrhs -rdimx 24 -rdimv 60 -rdime 20 -romxandv -efx 0.99999
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -restore -romsrhs -rdimx 24 -rdimv 60 -rdime 20 -romxandv -efx 0.99999 -soldiff -romos -rostype load
     ;;
 esac

--- a/rom/tests/sedov-blast-merge/sedov-blast-usevx.sh
+++ b/rom/tests/sedov-blast-merge/sedov-blast-usevx.sh
@@ -5,10 +5,10 @@ case $subTestNum in
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.05 -offline -ef 0.9999 -writesol -romsvds -romos -rostype load -romsrhs -romvx -efx 0.999999
     ;;
   2)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.05 -online -romsvds -romos -rostype load -sfacx 10 -sfacv 10 -sface 10 -soldiff -romsrhs -romgs -romhrprep -rdimx 66 -rdime 20 -rdimfv 111 -rdimfe 40 -romvx
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.05 -online -romsvds -romos -rostype load -sfacx 10 -sfacv 10 -sface 10 -soldiff -romsrhs -romgs -romhr -rdimx 66 -rdime 20 -rdimfv 111 -rdimfe 40 -romvx
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.05 -online -romsvds -romos -rostype load -sfacx 10 -sfacv 10 -sface 10 -romsrhs -romgs -romhrprep -rdimx 66 -rdime 20 -rdimfv 111 -rdimfe 40 -romvx
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.05 -online -romsvds -romos -rostype load -sfacx 10 -sfacv 10 -sface 10 -romsrhs -romgs -romhr -rdimx 66 -rdime 20 -rdimfv 111 -rdimfe 40 -romvx
     ;;
   3)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -restore -romsrhs -rdimx 66 -rdime 20 -romvx
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -restore -romsrhs -rdimx 66 -rdime 20 -romvx -soldiff -romos -rostype load
     ;;
 esac

--- a/rom/tests/sedov-blast-merge/sedov-blast-usexv.sh
+++ b/rom/tests/sedov-blast-merge/sedov-blast-usexv.sh
@@ -5,10 +5,10 @@ case $subTestNum in
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.05 -offline -ef 0.9999 -writesol -romsvds -romos -rostype load -romsrhs -romxv
     ;;
   2)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.05 -online -romsvds -romos -rostype load -sfacx 10 -sfacv 10 -sface 10 -soldiff -romsrhs -romgs -romhrprep -rdimv 60 -rdime 20 -rdimfv 111 -rdimfe 40 -romxv
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.05 -online -romsvds -romos -rostype load -sfacx 10 -sfacv 10 -sface 10 -soldiff -romsrhs -romgs -romhr -rdimv 60 -rdime 20 -rdimfv 111 -rdimfe 40 -romxv
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.05 -online -romsvds -romos -rostype load -sfacx 10 -sfacv 10 -sface 10 -romsrhs -romgs -romhrprep -rdimv 60 -rdime 20 -rdimfv 111 -rdimfe 40 -romxv
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.05 -online -romsvds -romos -rostype load -sfacx 10 -sfacv 10 -sface 10 -romsrhs -romgs -romhr -rdimv 60 -rdime 20 -rdimfv 111 -rdimfe 40 -romxv
     ;;
   3)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -restore -romsrhs -rdimv 60 -rdime 20 -romxv
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -restore -romsrhs -rdimv 60 -rdime 20 -romxv -soldiff -romos -rostype load
     ;;
 esac

--- a/rom/tests/sedov-blast-randomized/sedov-blast-randomized.sh
+++ b/rom/tests/sedov-blast-randomized/sedov-blast-randomized.sh
@@ -8,14 +8,14 @@ case $subTestNum in
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 11 -rdime 5 -sfacx 6 -sfacv 20 -sface 2 -soldiff
     ;;
   3)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romhrprep -rdimx 2 -rdimv 11 -rdime 5 -sfacx 6 -sfacv 20 -sface 2 -soldiff
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romhr -rdimx 2 -rdimv 11 -rdime 5 -sfacx 6 -sfacv 20 -sface 2 -soldiff
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romhrprep -rdimx 2 -rdimv 11 -rdime 5 -sfacx 6 -sfacv 20 -sface 2
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romhr -rdimx 2 -rdimv 11 -rdime 5 -sfacx 6 -sfacv 20 -sface 2
     ;;
   4)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 11 -rdime 5 -romhrprep -qdeim -soldiff
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 11 -rdime 5 -romhr -qdeim -soldiff
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 11 -rdime 5 -romhrprep -qdeim
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 11 -rdime 5 -romhr -qdeim
     ;;
   5)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -restore -rdimx 2 -rdimv 11 -rdime 5
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -restore -rdimx 2 -rdimv 11 -rdime 5 -soldiff
     ;;
 esac

--- a/rom/tests/sedov-blast/sedov-blast-parameter-variation.sh
+++ b/rom/tests/sedov-blast/sedov-blast-parameter-variation.sh
@@ -7,7 +7,7 @@ case $subTestNum in
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -bef 0.5 -writesol
     ;;
   2)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 7 -rdimv 12 -rdime 6 -rdimfv 15 -rdimfe 9 -romhrprep -romos -rostype interpolate -sfacx 1 -sfacv 32 -sface 32 -soldiff -romgs -romsrhs -bef 1.0
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 7 -rdimv 12 -rdime 6 -rdimfv 15 -rdimfe 9 -romhr -romos -rostype interpolate -sfacx 1 -sfacv 32 -sface 32 -soldiff -romgs -romsrhs -bef 1.0
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 7 -rdimv 12 -rdime 6 -rdimfv 15 -rdimfe 9 -romhrprep -romos -rostype interpolate -sfacx 1 -sfacv 32 -sface 32 -romgs -romsrhs -bef 1.0
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 7 -rdimv 12 -rdime 6 -rdimfv 15 -rdimfe 9 -romhr -romos -rostype interpolate -sfacx 1 -sfacv 32 -sface 32 -romgs -romsrhs -bef 1.0
     ;;
 esac

--- a/rom/tests/sedov-blast/sedov-blast-time-window-rhsbasis-parameter-variation-initial.sh
+++ b/rom/tests/sedov-blast/sedov-blast-time-window-rhsbasis-parameter-variation-initial.sh
@@ -6,7 +6,7 @@ case $subTestNum in
     $MERGE -nset 1 -romos -rostype initial -rhs -nwin 2 -tw "$BASE_DIR"/tests/sedov-blast/sedov-blast-time-window-rhsbasis-parameter-variation.csv
     ;;
   2)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.025 -online -romhrprep -romos -rostype initial -sfacx 1 -sfacv 32 -sface 32 -soldiff -romgs -romsrhs -bef 1.0 -nwin 2 -tw "$BASE_DIR"/tests/sedov-blast/sedov-blast-time-window-rhsbasis-parameter-variation.csv -twp twpTemp.csv
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.025 -online -romhr -romos -rostype initial -sfacx 1 -sfacv 32 -sface 32 -soldiff -romgs -romsrhs -bef 1.0 -nwin 2 -tw "$BASE_DIR"/tests/sedov-blast/sedov-blast-time-window-rhsbasis-parameter-variation.csv -twp twpTemp.csv
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.025 -online -romhrprep -romos -rostype initial -sfacx 1 -sfacv 32 -sface 32 -romgs -romsrhs -bef 1.0 -nwin 2 -tw "$BASE_DIR"/tests/sedov-blast/sedov-blast-time-window-rhsbasis-parameter-variation.csv -twp twpTemp.csv
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.025 -online -romhr -romos -rostype initial -sfacx 1 -sfacv 32 -sface 32 -romgs -romsrhs -bef 1.0 -nwin 2 -tw "$BASE_DIR"/tests/sedov-blast/sedov-blast-time-window-rhsbasis-parameter-variation.csv -twp twpTemp.csv
     ;;
 esac

--- a/rom/tests/sedov-blast/sedov-blast-time-window-rhsbasis-parameter-variation-interpolate.sh
+++ b/rom/tests/sedov-blast/sedov-blast-time-window-rhsbasis-parameter-variation-interpolate.sh
@@ -6,7 +6,7 @@ case $subTestNum in
     $MERGE -nset 1 -romos -rostype interpolate -rhs -nwin 2 -tw "$BASE_DIR"/tests/sedov-blast/sedov-blast-time-window-rhsbasis-parameter-variation.csv
     ;;
   2)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.025 -online -romhrprep -romos -rostype interpolate -sfacx 1 -sfacv 32 -sface 32 -soldiff -romgs -romsrhs -bef 1.0 -nwin 2 -tw "$BASE_DIR"/tests/sedov-blast/sedov-blast-time-window-rhsbasis-parameter-variation.csv -twp twpTemp.csv
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.025 -online -romhr -romos -rostype interpolate -sfacx 1 -sfacv 32 -sface 32 -soldiff -romgs -romsrhs -bef 1.0 -nwin 2 -tw "$BASE_DIR"/tests/sedov-blast/sedov-blast-time-window-rhsbasis-parameter-variation.csv -twp twpTemp.csv
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.025 -online -romhrprep -romos -rostype interpolate -sfacx 1 -sfacv 32 -sface 32 -romgs -romsrhs -bef 1.0 -nwin 2 -tw "$BASE_DIR"/tests/sedov-blast/sedov-blast-time-window-rhsbasis-parameter-variation.csv -twp twpTemp.csv
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.025 -online -romhr -romos -rostype interpolate -sfacx 1 -sfacv 32 -sface 32 -romgs -romsrhs -bef 1.0 -nwin 2 -tw "$BASE_DIR"/tests/sedov-blast/sedov-blast-time-window-rhsbasis-parameter-variation.csv -twp twpTemp.csv
     ;;
 esac

--- a/rom/tests/sedov-blast/sedov-blast-time-window-rhsbasis-parameter-variation-numsamp.sh
+++ b/rom/tests/sedov-blast/sedov-blast-time-window-rhsbasis-parameter-variation-numsamp.sh
@@ -6,7 +6,7 @@ case $subTestNum in
     $MERGE -nset 1 -romos -rostype interpolate -rhs -nwinsamp 20 -nwinover 5
     ;;
   2)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.025 -online -romhrprep -romos -rostype interpolate -sfacx 1 -sfacv 32 -sface 32 -soldiff -romgs -romsrhs -bef 1.0 -nwin 2 -twp twpTemp.csv
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.025 -online -romhr -romos -rostype interpolate -sfacx 1 -sfacv 32 -sface 32 -soldiff -romgs -romsrhs -bef 1.0 -nwin 2 -twp twpTemp.csv
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.025 -online -romhrprep -romos -rostype interpolate -sfacx 1 -sfacv 32 -sface 32 -romgs -romsrhs -bef 1.0 -nwin 2 -twp twpTemp.csv
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.025 -online -romhr -romos -rostype interpolate -sfacx 1 -sfacv 32 -sface 32 -romgs -romsrhs -bef 1.0 -nwin 2 -twp twpTemp.csv
     ;;
 esac

--- a/rom/tests/sedov-blast/sedov-blast-time-window-rhsbasis.sh
+++ b/rom/tests/sedov-blast/sedov-blast-time-window-rhsbasis.sh
@@ -8,10 +8,10 @@ case $subTestNum in
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.025 -online -romsvds -romos -rostype load -sfacx 10 -sfacv 10 -sface 10 -soldiff -romsrhs -nwin 2 -twp twpTemp.csv -romgs
     ;;
   3)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.025 -online -romsvds -romos -rostype load -sfacx 10 -sfacv 10 -sface 10 -soldiff -romsrhs -nwin 2 -twp twpTemp.csv -romgs -romhrprep
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.025 -online -romsvds -romos -rostype load -sfacx 10 -sfacv 10 -sface 10 -soldiff -romsrhs -nwin 2 -twp twpTemp.csv -romgs -romhr
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.025 -online -romsvds -romos -rostype load -sfacx 10 -sfacv 10 -sface 10 -romsrhs -nwin 2 -twp twpTemp.csv -romgs -romhrprep
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.025 -online -romsvds -romos -rostype load -sfacx 10 -sfacv 10 -sface 10 -romsrhs -nwin 2 -twp twpTemp.csv -romgs -romhr
     ;;
   4)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -restore -nwin 2 -twp twpTemp.csv -romsrhs
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -restore -nwin 2 -twp twpTemp.csv -romsrhs -soldiff -romos -rostype load
     ;;
 esac

--- a/rom/tests/sedov-blast/sedov-blast-time-window.sh
+++ b/rom/tests/sedov-blast/sedov-blast-time-window.sh
@@ -8,10 +8,10 @@ case $subTestNum in
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -nwin 4 -twp twpTemp.csv -soldiff
     ;;
   3)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romhrprep -nwin 4 -twp twpTemp.csv -soldiff
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romhr -nwin 4 -twp twpTemp.csv -soldiff
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romhrprep -nwin 4 -twp twpTemp.csv
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romhr -nwin 4 -twp twpTemp.csv
     ;;
   4)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -restore -nwin 4 -twp twpTemp.csv
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -restore -nwin 4 -twp twpTemp.csv -soldiff
     ;;
 esac

--- a/rom/tests/sedov-blast/sedov-blast.sh
+++ b/rom/tests/sedov-blast/sedov-blast.sh
@@ -8,14 +8,14 @@ case $subTestNum in
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 12 -rdime 16 -nsamx 12 -nsamv 184 -nsame 30 -soldiff
     ;;
   3)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 12 -rdime 16 -romhrprep -nsamx 4 -nsamv 24 -nsame 32 -soldiff
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 12 -rdime 16 -romhr -nsamx 4 -nsamv 24 -nsame 32 -soldiff
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 12 -rdime 16 -romhrprep -nsamx 4 -nsamv 24 -nsame 32
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 12 -rdime 16 -romhr -nsamx 4 -nsamv 24 -nsame 32
     ;;
   4)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 12 -rdime 16 -romhrprep -qdeim -soldiff
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 12 -rdime 16 -romhr -qdeim -soldiff
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 12 -rdime 16 -romhrprep -qdeim
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 12 -rdime 16 -romhr -qdeim
     ;;
   5)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -restore -rdimx 2 -rdimv 12 -rdime 16
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -restore -rdimx 2 -rdimv 12 -rdime 16 -soldiff
     ;;
 esac

--- a/rom/tests/taylor-green/taylor-green-time-window.sh
+++ b/rom/tests/taylor-green/taylor-green-time-window.sh
@@ -8,10 +8,10 @@ case $subTestNum in
     $LAGHOS -p 0 -rs 2 -iv -cfl 0.5 -tf 0.008 -pa -online -soldiff -nwin 2 -twp twpTemp.csv
     ;;
   3)
-    $LAGHOS -p 0 -rs 2 -iv -cfl 0.5 -tf 0.008 -pa -online -romhrprep -soldiff -nwin 2 -twp twpTemp.csv
-    $LAGHOS_SERIAL -p 0 -rs 2 -iv -cfl 0.5 -tf 0.008 -pa -online -romhr -soldiff -nwin 2 -twp twpTemp.csv
+    $LAGHOS -p 0 -rs 2 -iv -cfl 0.5 -tf 0.008 -pa -online -romhrprep -nwin 2 -twp twpTemp.csv
+    $LAGHOS_SERIAL -p 0 -rs 2 -iv -cfl 0.5 -tf 0.008 -pa -online -romhr -nwin 2 -twp twpTemp.csv
     ;;
   4)
-    $LAGHOS -p 0 -rs 2 -iv -cfl 0.5 -tf 0.008 -pa -restore -nwin 2 -twp twpTemp.csv
+    $LAGHOS -p 0 -rs 2 -iv -cfl 0.5 -tf 0.008 -pa -restore -nwin 2 -twp twpTemp.csv -soldiff
     ;;
 esac

--- a/rom/tests/taylor-green/taylor-green.sh
+++ b/rom/tests/taylor-green/taylor-green.sh
@@ -8,10 +8,10 @@ case $subTestNum in
     $LAGHOS -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -online -rdimx 2 -rdimv 6 -rdime 2 -soldiff
     ;;
   3)
-    $LAGHOS -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -online -rdimx 2 -rdimv 6 -rdime 2 -soldiff -romhrprep -nsamx 96 -nsamv 320 -nsame 64
-    $LAGHOS_SERIAL -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -online -rdimx 2 -rdimv 6 -rdime 2 -soldiff -romhr -nsamx 96 -nsamv 320 -nsame 64
+    $LAGHOS -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -online -rdimx 2 -rdimv 6 -rdime 2 -romhrprep -nsamx 96 -nsamv 320 -nsame 64
+    $LAGHOS_SERIAL -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -online -rdimx 2 -rdimv 6 -rdime 2 -romhr -nsamx 96 -nsamv 320 -nsame 64
     ;;
   4)
-    $LAGHOS -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -restore -rdimx 2 -rdimv 6 -rdime 2
+    $LAGHOS -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -restore -rdimx 2 -rdimv 6 -rdime 2 -soldiff
     ;;
 esac

--- a/rom/tests/triple-point/absolute-triple-point.sh
+++ b/rom/tests/triple-point/absolute-triple-point.sh
@@ -11,7 +11,7 @@ case $subTestNum in
     $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.2 -cfl 0.05 -pa -offline -writesol -romsvds -rostype load
     ;;
   2)
-    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.2 -cfl 0.05 -pa -online -rdimx 3 -rdimv 7 -rdime 5 -romhrprep -nsamx 6 -nsamv 448 -nsame 10 -soldiff -rostype load
-    $LAGHOS_SERIAL -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.2 -cfl 0.05 -pa -online -rdimx 3 -rdimv 7 -rdime 5 -romhr -nsamx 6 -nsamv 448 -nsame 10 -soldiff -rostype load
+    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.2 -cfl 0.05 -pa -online -rdimx 3 -rdimv 7 -rdime 5 -romhrprep -nsamx 6 -nsamv 448 -nsame 10 -rostype load
+    $LAGHOS_SERIAL -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.2 -cfl 0.05 -pa -online -rdimx 3 -rdimv 7 -rdime 5 -romhr -nsamx 6 -nsamv 448 -nsame 10 -rostype load
     ;;
 esac

--- a/rom/tests/triple-point/triple-point-time-window.sh
+++ b/rom/tests/triple-point/triple-point-time-window.sh
@@ -8,10 +8,10 @@ case $subTestNum in
     $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -soldiff -nwin 4 -twp twpTemp.csv
     ;;
   3)
-    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -soldiff -nwin 4 -romhrprep -twp twpTemp.csv
-    $LAGHOS_SERIAL -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -soldiff -nwin 4 -romhr -twp twpTemp.csv
+    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -nwin 4 -romhrprep -twp twpTemp.csv
+    $LAGHOS_SERIAL -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -nwin 4 -romhr -twp twpTemp.csv
     ;;
   4)
-    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -restore -nwin 4 -twp twpTemp.csv
+    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -restore -nwin 4 -twp twpTemp.csv -soldiff
     ;;
 esac

--- a/rom/tests/triple-point/triple-point.sh
+++ b/rom/tests/triple-point/triple-point.sh
@@ -8,10 +8,10 @@ case $subTestNum in
     $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -rdimx 1 -rdimv 4 -rdime 3 -soldiff
     ;;
   3)
-    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -rdimx 1 -rdimv 4 -rdime 3 -romhrprep -nsamx 6 -nsamv 448 -nsame 10 -soldiff
-    $LAGHOS_SERIAL -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -rdimx 1 -rdimv 4 -rdime 3 -romhr -nsamx 6 -nsamv 448 -nsame 10 -soldiff
+    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -rdimx 1 -rdimv 4 -rdime 3 -romhrprep -nsamx 6 -nsamv 448 -nsame 10
+    $LAGHOS_SERIAL -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -rdimx 1 -rdimv 4 -rdime 3 -romhr -nsamx 6 -nsamv 448 -nsame 10
     ;;
   4)
-    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -restore -rdimx 1 -rdimv 4 -rdime 3
+    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -restore -rdimx 1 -rdimv 4 -rdime 3 -soldiff
     ;;
 esac


### PR DESCRIPTION
The following test was showing large error from the `-soldiff` calculation in the restore phase, because the online ROM solution was being output to file in the Gram-Schmidt coordinates. This PR outputs the standard ROM coordinates, so that the restore phase correctly computes errors.

laghos -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -offline -writesol -romsvds -romos -romsrhs -rostype initial

laghos -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -online -romhrprep -romsvds -sfacx 10 -sfacv 100 -sface 100 -romos -romsrhs -rdimx 9 -rdimv 21 -rdime 30 -rdimfv 29 -rdimfe 33 -rostype initial -romgs

laghos -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -online -romhr -romsvds -sfacx 10 -sfacv 100 -sface 100 -romos -romsrhs -rdimx 9 -rdimv 21 -rdime 30 -rdimfv 29 -rdimfe 33 -rostype initial -romgs

laghos -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -pa -restore -romos -romsrhs -rdimx 9 -rdimv 21 -rdime 30 -rostype initial -soldiff