### PR TITLE
SNS implementation

### DIFF
--- a/rom/laghos.cpp
+++ b/rom/laghos.cpp
@@ -575,6 +575,10 @@ int main(int argc, char *argv[])
     romOptions.offsetType = getOffsetStyle(offsetType);
     if (rom_online)
     {
+        std::string filename = outputPath + "/ROMsol/romS_1";
+        std::ifstream infile_romS(filename.c_str());
+        MFEM_VERIFY(!infile_romS.good(), "ROMsol files already exist.")
+
         std::ifstream infile_offlineParam(offlineParam_outputPath);
         MFEM_VERIFY(infile_offlineParam.is_open(), "Offline parameter record file does not exist.");
         std::string line;

--- a/rom/laghos.cpp
+++ b/rom/laghos.cpp
@@ -299,6 +299,8 @@ int main(int argc, char *argv[])
     args.AddOption(&romOptions.incSVD_sampling_tol, "-samptol", "--samplingtol", "The incremental SVD model sampling tolerance.");
     args.AddOption(&romOptions.RHSbasis, "-romsrhs", "--romsamplerhs", "-no-romsrhs", "--no-romsamplerhs",
                    "Sample RHS");
+    args.AddOption(&romOptions.SNS, "-romsns", "--romsns", "-no-romsns", "--no-romsns",
+                   "Enable or disable SNS in hyperreduction on Fv and Fe");
     args.AddOption(&romOptions.GramSchmidt, "-romgs", "--romgramschmidt", "-no-romgs", "--no-romgramschmidt",
                    "Enable or disable Gram-Schmidt orthonormalization on V and E induced by mass matrices.");
     args.AddOption(&romOptions.rhoFactor, "-rhof", "--rhofactor", "Factor for scaling rho.");
@@ -1241,7 +1243,7 @@ int main(int argc, char *argv[])
             outfile_tw_steps.open(outputPath + "/tw_steps");
         }
         timeLoopTimer.Start();
-        if (romOptions.hyperreduce && romOptions.GramSchmidt)
+        if (romOptions.hyperreduce)
         {
             romOper[0]->InducedGramSchmidtInitialize(romS);
         }
@@ -1457,7 +1459,7 @@ int main(int argc, char *argv[])
                     if (myid == 0)
                         cout << "ROM online basis change for window " << romOptions.window << " at t " << t << ", dt " << dt << endl;
 
-                    if (romOptions.hyperreduce && romOptions.GramSchmidt)
+                    if (romOptions.hyperreduce)
                     {
                         romOper[romOptions.window-1]->InducedGramSchmidtFinalize(romS);
                     }
@@ -1503,7 +1505,7 @@ int main(int argc, char *argv[])
 
                     delete romOper[romOptions.window-1];
 
-                    if (romOptions.hyperreduce && romOptions.GramSchmidt)
+                    if (romOptions.hyperreduce)
                     {
                         romOper[romOptions.window]->InducedGramSchmidtInitialize(romS);
                     }

--- a/rom/laghos.cpp
+++ b/rom/laghos.cpp
@@ -1250,7 +1250,7 @@ int main(int argc, char *argv[])
         timeLoopTimer.Start();
         if (romOptions.hyperreduce)
         {
-            romOper[0]->InducedGramSchmidtInitialize(romS);
+            romOper[0]->ApplyHyperreduction(romS);
         }
         double tOverlapMidpoint = 0.0;
         for (int ti = 1; !last_step; ti++)
@@ -1305,7 +1305,7 @@ int main(int argc, char *argv[])
                 if (romOptions.hyperreduce && romOptions.GramSchmidt)
                 {
                     Vector romCoord(romS);
-                    romOper[romOptions.window]->InducedGramSchmidtFinalize(romCoord, true);
+                    romOper[romOptions.window]->PostprocessHyperreduction(romCoord, true);
                     romCoord.Print(outfile_romS, 1);
                 }
                 else
@@ -1464,7 +1464,7 @@ int main(int argc, char *argv[])
 
                     if (romOptions.hyperreduce)
                     {
-                        romOper[romOptions.window-1]->InducedGramSchmidtFinalize(romS);
+                        romOper[romOptions.window-1]->PostprocessHyperreduction(romS);
                     }
 
                     int rdimxprev = romOptions.dimX;
@@ -1510,7 +1510,7 @@ int main(int argc, char *argv[])
 
                     if (romOptions.hyperreduce)
                     {
-                        romOper[romOptions.window]->InducedGramSchmidtInitialize(romS);
+                        romOper[romOptions.window]->ApplyHyperreduction(romS);
                     }
                     ode_solver->Init(*romOper[romOptions.window]);
                 }
@@ -1626,7 +1626,7 @@ int main(int argc, char *argv[])
     {
         if (romOptions.GramSchmidt)
         {
-            romOper[romOptions.window]->InducedGramSchmidtFinalize(romS);
+            romOper[romOptions.window]->PostprocessHyperreduction(romS);
         }
         if (!rom_online)
         {

--- a/rom/laghos.cpp
+++ b/rom/laghos.cpp
@@ -1013,7 +1013,8 @@ int main(int argc, char *argv[])
 
         samplerTimer.Start();
         if (usingWindows && romOptions.parameterID == -1) {
-            outfile_twp.open(outputPath + twpfile);
+            //outfile_twp.open(outputPath + twpfile);
+            outfile_twp.open(outputPath + "twpTemp.csv");
         }
         const double tf = (usingWindows && windowNumSamples == 0) ? twep[0] : t_final;
         romOptions.t_final = tf;

--- a/rom/laghos.cpp
+++ b/rom/laghos.cpp
@@ -376,6 +376,11 @@ int main(int argc, char *argv[])
     else  // not using windows
     {
         numWindows = 1;  // one window for the entire simulation
+        if (romOptions.SNS)
+        {
+            romOptions.dimFv = max(romOptions.dimFv, romOptions.dimV);
+            romOptions.dimFe = max(romOptions.dimFe, romOptions.dimE);
+        }
     }
 
     if (windowNumSamples > 0) romOptions.max_dim = windowNumSamples + windowOverlapSamples + 2;

--- a/rom/laghos.cpp
+++ b/rom/laghos.cpp
@@ -364,7 +364,7 @@ int main(int argc, char *argv[])
         if (rom_online || rom_restore)
         {
             double sFactor[]  = {sFactorX, sFactorV, sFactorE};
-            const int err = ReadTimeWindowParameters(numWindows, outputPath + "/" + std::string(twpfile), twep, twparam, sFactor, myid == 0, romOptions.RHSbasis);
+            const int err = ReadTimeWindowParameters(numWindows, outputPath + "/" + std::string(twpfile), twep, twparam, sFactor, myid == 0, romOptions.SNS);
             MFEM_VERIFY(err == 0, "Error in ReadTimeWindowParameters");
         }
         else if (rom_offline && windowNumSamples == 0)
@@ -934,7 +934,7 @@ int main(int argc, char *argv[])
                 std::ofstream outfile_offlineParam(offlineParam_outputPath);
                 outfile_offlineParam << romOptions.useOffset << " ";
                 outfile_offlineParam << romOptions.offsetType << " ";
-                outfile_offlineParam << romOptions.RHSbasis << " ";
+                outfile_offlineParam << romOptions.SNS << " ";
                 outfile_offlineParam << numWindows << " ";
                 outfile_offlineParam << twfile << endl;
                 outfile_offlineParam << romOptions.parameterID << " ";
@@ -956,7 +956,7 @@ int main(int argc, char *argv[])
             split_line(line, words);
             MFEM_VERIFY(std::stoi(words[0]) == romOptions.useOffset, "-romos option does not match record.");
             MFEM_VERIFY(std::stoi(words[1]) == romOptions.offsetType, "-romostype option does not match record.");
-            MFEM_VERIFY(std::stoi(words[2]) == romOptions.RHSbasis, "-romsrhs option does not match record.");
+            MFEM_VERIFY(std::stoi(words[2]) == romOptions.SNS, "-romsns option does not match record.");
             MFEM_VERIFY(std::stoi(words[3]) == numWindows, "-nwin option does not match record.");
             MFEM_VERIFY(std::strcmp(words[4].c_str(), twfile) == 0, "-tw option does not match record.");
             infile_offlineParam.close();
@@ -1023,8 +1023,8 @@ int main(int argc, char *argv[])
     if (!usingWindows)
     {
         if (romOptions.sampX == 0 && !romOptions.mergeXV) romOptions.sampX = sFactorX * romOptions.dimX;
-        if (romOptions.sampV == 0 && !romOptions.mergeXV) romOptions.sampV = sFactorV * (romOptions.RHSbasis ? romOptions.dimFv : romOptions.dimV);
-        if (romOptions.sampE == 0) romOptions.sampE = sFactorE * (romOptions.RHSbasis ? romOptions.dimFe : romOptions.dimE);
+        if (romOptions.sampV == 0 && !romOptions.mergeXV) romOptions.sampV = sFactorV * romOptions.dimFv;
+        if (romOptions.sampE == 0) romOptions.sampE = sFactorE * romOptions.dimFe;
     }
 
     StopWatch onlinePreprocessTimer;
@@ -1402,12 +1402,11 @@ int main(int argc, char *argv[])
 
                         MFEM_VERIFY(tOverlapMidpoint > 0.0, "Overlapping window endpoint undefined.");
                         if (myid == 0 && romOptions.parameterID == -1) {
-                            outfile_twp << tOverlapMidpoint << ", ";
-                            if (romOptions.RHSbasis)
-                                outfile_twp << cutoff[0] << ", " << cutoff[1] << ", " << cutoff[2] << ", "
-                                            << cutoff[3] << ", " << cutoff[4] << "\n";
+                            outfile_twp << tOverlapMidpoint << ", " << cutoff[0] << ", " << cutoff[1] << ", " << cutoff[2];
+                            if (romOptions.SNS)
+                                outfile_twp << "\n";
                             else
-                                outfile_twp << cutoff[0] << ", " << cutoff[1] << ", " << cutoff[2] << "\n";
+                                outfile_twp << ", " << cutoff[3] << ", " << cutoff[4] << "\n";
                         }
                         delete samplerLast;
                         samplerLast = NULL;
@@ -1425,12 +1424,11 @@ int main(int argc, char *argv[])
                     {
                         sampler->Finalize(t, last_dt, *S, cutoff);
                         if (myid == 0 && romOptions.parameterID == -1) {
-                            outfile_twp << t << ", ";
-                            if (romOptions.RHSbasis)
-                                outfile_twp << cutoff[0] << ", " << cutoff[1] << ", " << cutoff[2] << ", "
-                                            << cutoff[3] << ", " << cutoff[4] << "\n";
+                            outfile_twp << t << ", " << cutoff[0] << ", " << cutoff[1] << ", " << cutoff[2];
+                            if (romOptions.SNS)
+                                outfile_twp << "\n";
                             else
-                                outfile_twp << cutoff[0] << ", " << cutoff[1] << ", " << cutoff[2] << "\n";
+                                outfile_twp << ", " << cutoff[3] << ", " << cutoff[4] << "\n";
                         }
                         delete sampler;
                     }
@@ -1642,13 +1640,12 @@ int main(int argc, char *argv[])
         basisConstructionTimer.Stop();
 
         if (myid == 0 && usingWindows && sampler != NULL && romOptions.parameterID == -1) {
-            outfile_twp << t << ", ";
+            outfile_twp << t << ", " << cutoff[0] << ", " << cutoff[1] << ", " << cutoff[2];
 
-            if (romOptions.RHSbasis)
-                outfile_twp << cutoff[0] << ", " << cutoff[1] << ", " << cutoff[2] << ", "
-                            << cutoff[3] << ", " << cutoff[4] << "\n";
+            if (romOptions.SNS)
+                outfile_twp << "\n";
             else
-                outfile_twp << cutoff[0] << ", " << cutoff[1] << ", " << cutoff[2] << "\n";
+                outfile_twp << ", " << cutoff[3] << ", " << cutoff[4] << "\n";
         }
         if (samplerLast == sampler)
             delete sampler;

--- a/rom/laghos.cpp
+++ b/rom/laghos.cpp
@@ -1009,7 +1009,7 @@ int main(int argc, char *argv[])
 
         samplerTimer.Start();
         if (usingWindows && romOptions.parameterID == -1) {
-            outfile_twp.open(outputPath + "/twpTemp.csv");
+            outfile_twp.open(outputPath + twpfile);
         }
         const double tf = (usingWindows && windowNumSamples == 0) ? twep[0] : t_final;
         romOptions.t_final = tf;

--- a/rom/laghos.cpp
+++ b/rom/laghos.cpp
@@ -1013,8 +1013,8 @@ int main(int argc, char *argv[])
 
         samplerTimer.Start();
         if (usingWindows && romOptions.parameterID == -1) {
-            //outfile_twp.open(outputPath + twpfile);
-            outfile_twp.open(outputPath + "twpTemp.csv");
+            //outfile_twp.open(outputPath + "/" + std::string(twpfile));
+            outfile_twp.open(outputPath + "/twpTemp.csv");
         }
         const double tf = (usingWindows && windowNumSamples == 0) ? twep[0] : t_final;
         romOptions.t_final = tf;

--- a/rom/laghos_rom.cpp
+++ b/rom/laghos_rom.cpp
@@ -281,9 +281,10 @@ CAROM::Matrix* ReadBasisROM(const int rank, const std::string filename, const in
     return basisCopy;
 }
 
-CAROM::Matrix* MultM(hydrodynamics::LagrangianHydroOperator *lhoper, const int var, const int N, const CAROM::Matrix* A)
+CAROM::Matrix* MultBasisROM(const int rank, const std::string filename, const int vectorSize, const int rowOS, int& dim, hydrodynamics::LagrangianHydroOperator *lhoper, const int var)
 {
-    CAROM::Matrix* S = new CAROM::Matrix(A->numRows(), std::min(N, A->numColumns()), A->distributed());
+    CAROM::Matrix* A = ReadBasisROM(rank, filename, vectorSize, rowOS, dim);
+    CAROM::Matrix* S = new CAROM::Matrix(A->numRows(), A->numColumns(), A->distributed());
     Vector Bej(A->numRows());
     Vector MBej(A->numRows());
 
@@ -1404,8 +1405,8 @@ void ROM_Basis::ReadSolutionBases(const int window)
     }
     else
     {
-        basisFv = MultM(lhoper, 1, rdimfv, basisV);
-        basisFe = MultM(lhoper, 2, rdimfe, basisE);
+        basisFv = MultBasisROM(rank, basename + "/" + ROMBasisName::V + std::to_string(window), tH1size, 0, rdimfv, lhoper, 1);
+        basisFe = MultBasisROM(rank, basename + "/" + ROMBasisName::E + std::to_string(window), tL2size, 0, rdimfe, lhoper, 2);
     }
 }
 

--- a/rom/laghos_rom.cpp
+++ b/rom/laghos_rom.cpp
@@ -16,7 +16,7 @@ void ROM_Sampler::SampleSolution(const double t, const double dt, Vector const& 
     const bool sampleX = generator_X->isNextSample(t);
 
     Vector dSdt;
-    if (sampleF)
+    if (!sns)
     {
         dSdt.SetSize(S.Size());
         lhoper->Mult(S, dSdt);
@@ -91,7 +91,7 @@ void ROM_Sampler::SampleSolution(const double t, const double dt, Vector const& 
             }
         }
 
-        if (sampleF)
+        if (!sns)
         {
             MFEM_VERIFY(gfH1.Size() == H1size, "");
             for (int i=0; i<H1size; ++i)
@@ -135,7 +135,7 @@ void ROM_Sampler::SampleSolution(const double t, const double dt, Vector const& 
             generator_E->computeNextSampleTime(E.GetData(), dEdt.GetData(), t);
         }
 
-        if (sampleF)
+        if (!sns)
         {
             MFEM_VERIFY(gfL2.Size() == L2size, "");
             for (int i=0; i<L2size; ++i)
@@ -174,7 +174,7 @@ void ROM_Sampler::Finalize(const double t, const double dt, Vector const& S, Arr
         if (!useXV) generator_X->writeSnapshot();
         if (!useVX) generator_V->writeSnapshot();
         generator_E->writeSnapshot();
-        if (sampleF)
+        if (!sns)
         {
             generator_Fv->writeSnapshot();
             generator_Fe->writeSnapshot();
@@ -185,7 +185,7 @@ void ROM_Sampler::Finalize(const double t, const double dt, Vector const& S, Arr
         if (!useXV) generator_X->endSamples();
         if (!useVX) generator_V->endSamples();
         generator_E->endSamples();
-        if (sampleF)
+        if (!sns)
         {
             generator_Fv->endSamples();
             generator_Fe->endSamples();
@@ -212,7 +212,7 @@ void ROM_Sampler::Finalize(const double t, const double dt, Vector const& S, Arr
         BasisGeneratorFinalSummary(generator_E, energyFraction, cutoff[2]);
         PrintSingularValues(rank, basename, "E", generator_E);
 
-        if (sampleF)
+        if (!sns)
         {
             cout << "Fv basis summary output: ";
             BasisGeneratorFinalSummary(generator_Fv, energyFraction, cutoff[3]);
@@ -230,7 +230,7 @@ void ROM_Sampler::Finalize(const double t, const double dt, Vector const& S, Arr
         printSnapshotTime(tSnapV, path_tSnap, "V");
         printSnapshotTime(tSnapE, path_tSnap, "E");
 
-        if (sampleF)
+        if (!sns)
         {
             printSnapshotTime(tSnapFv, path_tSnap, "Fv");
             printSnapshotTime(tSnapFe, path_tSnap, "Fe");
@@ -241,7 +241,7 @@ void ROM_Sampler::Finalize(const double t, const double dt, Vector const& S, Arr
     delete generator_V;
     delete generator_E;
 
-    if (sampleF)
+    if (!sns)
     {
         delete generator_Fv;
         delete generator_Fe;

--- a/rom/laghos_rom.cpp
+++ b/rom/laghos_rom.cpp
@@ -1769,6 +1769,7 @@ ROM_Operator::ROM_Operator(ROM_Options const& input, ROM_Basis *b,
 
         sns1 = (input.SNS && input.dimV == input.dimFv && input.dimE == input.dimFe); // SNS type I
         noMsolve = (useReducedM || useGramSchmidt || sns1);
+        cout << "Window #" << input.window << ": sns1 = " << sns1 << endl;
 
         operSP = new hydrodynamics::LagrangianHydroOperator(S.Size(), *H1FESpaceSP, *L2FESpaceSP,
                 ess_tdofs, rho, source, cfl, mat_gf_coeff,

--- a/rom/laghos_rom.cpp
+++ b/rom/laghos_rom.cpp
@@ -1848,7 +1848,7 @@ void ROM_Basis::Set_dxdt_Reduced(const Vector &x, Vector &y) const
 
 void ROM_Basis::HyperreduceRHS_V(Vector &v) const
 {
-    if (!RHSbasis) return;
+    if (use_sns || !RHSbasis) return;
 
     MFEM_VERIFY(useGramSchmidt, "apply reduced mass matrix inverse");
     MFEM_VERIFY(v.Size() == size_H1_sp, "");
@@ -1867,7 +1867,7 @@ void ROM_Basis::HyperreduceRHS_V(Vector &v) const
 
 void ROM_Basis::HyperreduceRHS_E(Vector &e) const
 {
-    if (!RHSbasis) return;
+    if (use_sns || !RHSbasis) return;
 
     MFEM_VERIFY(useGramSchmidt, "apply reduced mass matrix inverse");
     MFEM_VERIFY(e.Size() == size_L2_sp, "");

--- a/rom/laghos_rom.cpp
+++ b/rom/laghos_rom.cpp
@@ -281,7 +281,8 @@ CAROM::Matrix* ReadBasisROM(const int rank, const std::string filename, const in
     return basisCopy;
 }
 
-CAROM::Matrix* MultBasisROM(const int rank, const std::string filename, const int vectorSize, const int rowOS, int& dim, hydrodynamics::LagrangianHydroOperator *lhoper, const int var)
+CAROM::Matrix* MultBasisROM(const int rank, const std::string filename, const int vectorSize, const int rowOS, int& dim,
+                            hydrodynamics::LagrangianHydroOperator *lhoper, const int var)
 {
     CAROM::Matrix* A = ReadBasisROM(rank, filename, vectorSize, rowOS, dim);
     CAROM::Matrix* S = new CAROM::Matrix(A->numRows(), A->numColumns(), A->distributed());
@@ -514,11 +515,11 @@ ROM_Basis::ROM_Basis(ROM_Options const& input, MPI_Comm comm_, const double sFac
     if (hyperreduce_prep)
     {
         if (rank == 0) cout << "start preprocessing hyper-reduction\n";
-        StopWatch preprocessHyperreductionTymer;
-        preprocessHyperreductionTymer.Start();
+        StopWatch preprocessHyperreductionTimer;
+        preprocessHyperreductionTimer.Start();
         SetupHyperreduction(input.H1FESpace, input.L2FESpace, nH1, input.window);
-        preprocessHyperreductionTymer.Stop();
-        if (rank == 0) cout << "Elapsed time for hyper-reduction preprocessing: " << preprocessHyperreductionTymer.RealTime() << " sec\n";
+        preprocessHyperreductionTimer.Stop();
+        if (rank == 0) cout << "Elapsed time for hyper-reduction preprocessing: " << preprocessHyperreductionTimer.RealTime() << " sec\n";
     }
 }
 
@@ -2258,7 +2259,7 @@ void ROM_Operator::UndoInducedGramSchmidt(const int var, Vector &S, bool keep_da
     }
 }
 
-void ROM_Operator::InducedGramSchmidtInitialize(Vector &S)
+void ROM_Operator::ApplyHyperreduction(Vector &S)
 {
     if (useGramSchmidt && !sns1)
     {
@@ -2269,7 +2270,7 @@ void ROM_Operator::InducedGramSchmidtInitialize(Vector &S)
     basis->ComputeReducedMatrices(sns1);
 }
 
-void ROM_Operator::InducedGramSchmidtFinalize(Vector &S, bool keep_data)
+void ROM_Operator::PostprocessHyperreduction(Vector &S, bool keep_data)
 {
     if (useGramSchmidt && !sns1)
     {

--- a/rom/laghos_rom.cpp
+++ b/rom/laghos_rom.cpp
@@ -1398,15 +1398,18 @@ void ROM_Basis::ReadSolutionBases(const int window)
         basisV = basisX;
     }
 
-    if (!use_sns)
+    if (hyperreduce)
     {
-        basisFv = ReadBasisROM(rank, basename + "/" + ROMBasisName::Fv + std::to_string(window), tH1size, 0, rdimfv);
-        basisFe = ReadBasisROM(rank, basename + "/" + ROMBasisName::Fe + std::to_string(window), tL2size, 0, rdimfe);
-    }
-    else
-    {
-        basisFv = MultBasisROM(rank, basename + "/" + ROMBasisName::V + std::to_string(window), tH1size, 0, rdimfv, lhoper, 1);
-        basisFe = MultBasisROM(rank, basename + "/" + ROMBasisName::E + std::to_string(window), tL2size, 0, rdimfe, lhoper, 2);
+        if (!use_sns)
+        {
+            basisFv = ReadBasisROM(rank, basename + "/" + ROMBasisName::Fv + std::to_string(window), tH1size, 0, rdimfv);
+            basisFe = ReadBasisROM(rank, basename + "/" + ROMBasisName::Fe + std::to_string(window), tL2size, 0, rdimfe);
+        }
+        else
+        {
+            basisFv = MultBasisROM(rank, basename + "/" + ROMBasisName::V + std::to_string(window), tH1size, 0, rdimfv, lhoper, 1);
+            basisFe = MultBasisROM(rank, basename + "/" + ROMBasisName::E + std::to_string(window), tL2size, 0, rdimfe, lhoper, 2);
+        }
     }
 }
 

--- a/rom/laghos_rom.cpp
+++ b/rom/laghos_rom.cpp
@@ -412,7 +412,16 @@ ROM_Basis::ROM_Basis(ROM_Options const& input, MPI_Comm comm_, const double sFac
 
         std::string path_init = basename + "/ROMoffset/init";
 
-        if (input.restore || input.offsetType == saveLoadOffset)
+        if (input.offsetType == useInitialState)
+        {
+            // Read offset in the online phase of initial mode
+            initX->read(path_init + "X0");
+            initV->read(path_init + "V0");
+            initE->read(path_init + "E0");
+
+            cout << "Read init vectors X, V, E with norms " << initX->norm() << ", " << initV->norm() << ", " << initE->norm() << endl;
+        }
+        else if (input.restore || input.offsetType == saveLoadOffset)
         {
             // Read offsets in the restore phase or in the online phase of non-parametric save-and-load mode
             initX->read(path_init + "X" + std::to_string(input.window));
@@ -500,15 +509,6 @@ ROM_Basis::ROM_Basis(ROM_Options const& input, MPI_Comm comm_, const double sFac
             initE->write(path_init + "E" + std::to_string(input.window));
 
             cout << "Interpolated init vectors X, V, E with norms " << initX->norm() << ", " << initV->norm() << ", " << initE->norm() << endl;
-        }
-        else if (input.offsetType == useInitialState && input.window > 0)
-        {
-            // Read offset in the online phase of initial mode
-            initX->read(path_init + "X0");
-            initV->read(path_init + "V0");
-            initE->read(path_init + "E0");
-
-            cout << "Read init vectors X, V, E with norms " << initX->norm() << ", " << initV->norm() << ", " << initE->norm() << endl;
         }
     }
 

--- a/rom/laghos_rom.cpp
+++ b/rom/laghos_rom.cpp
@@ -309,7 +309,7 @@ CAROM::Matrix* MultBasisROM(const int rank, const std::string filename, const in
 
 ROM_Basis::ROM_Basis(ROM_Options const& input, MPI_Comm comm_, const double sFactorX, const double sFactorV)
     : comm(comm_), rdimx(input.dimX), rdimv(input.dimV), rdime(input.dimE), rdimfv(input.dimFv), rdimfe(input.dimFe),
-      numSamplesX(input.sampX), numSamplesV(input.sampV), numSamplesE(input.sampE), use_sns(input.SNS),
+      numSamplesX(input.sampX), numSamplesV(input.sampV), numSamplesE(input.sampE), use_sns(input.SNS || !input.RHSbasis),
       hyperreduce(input.hyperreduce), hyperreduce_prep(input.hyperreduce_prep), offsetInit(input.useOffset),
       RHSbasis(input.RHSbasis), useGramSchmidt(input.GramSchmidt), lhoper(input.FOMoper),
       RK2AvgFormulation(input.RK2AvgSolver), basename(*input.basename),
@@ -1848,7 +1848,7 @@ void ROM_Basis::Set_dxdt_Reduced(const Vector &x, Vector &y) const
 
 void ROM_Basis::HyperreduceRHS_V(Vector &v) const
 {
-    if (use_sns || !RHSbasis) return;
+    if (use_sns) return;
 
     MFEM_VERIFY(useGramSchmidt, "apply reduced mass matrix inverse");
     MFEM_VERIFY(v.Size() == size_H1_sp, "");
@@ -1867,7 +1867,7 @@ void ROM_Basis::HyperreduceRHS_V(Vector &v) const
 
 void ROM_Basis::HyperreduceRHS_E(Vector &e) const
 {
-    if (use_sns || !RHSbasis) return;
+    if (use_sns) return;
 
     MFEM_VERIFY(useGramSchmidt, "apply reduced mass matrix inverse");
     MFEM_VERIFY(e.Size() == size_L2_sp, "");

--- a/rom/laghos_rom.cpp
+++ b/rom/laghos_rom.cpp
@@ -1361,15 +1361,15 @@ void ROM_Basis::ReadSolutionBases(const int window)
         basisV = basisX;
     }
 
-    if (!use_sns)
-    {
-        basisFv = ReadBasisROM(rank, basename + "/" + ROMBasisName::Fv + std::to_string(window), tH1size, 0, rdimfv);
-        basisFe = ReadBasisROM(rank, basename + "/" + ROMBasisName::Fe + std::to_string(window), tL2size, 0, rdimfe);
-    }
-    else
+    if (use_sns)
     {
         basisFv = MultBasisROM(rank, basename + "/" + ROMBasisName::V + std::to_string(window), tH1size, 0, rdimfv, lhoper, 1);
         basisFe = MultBasisROM(rank, basename + "/" + ROMBasisName::E + std::to_string(window), tL2size, 0, rdimfe, lhoper, 2);
+    }
+    else
+    {
+        basisFv = ReadBasisROM(rank, basename + "/" + ROMBasisName::Fv + std::to_string(window), tH1size, 0, rdimfv);
+        basisFe = ReadBasisROM(rank, basename + "/" + ROMBasisName::Fe + std::to_string(window), tL2size, 0, rdimfe);
     }
 }
 

--- a/rom/laghos_rom.cpp
+++ b/rom/laghos_rom.cpp
@@ -311,7 +311,7 @@ ROM_Basis::ROM_Basis(ROM_Options const& input, MPI_Comm comm_, const double sFac
     : comm(comm_), rdimx(input.dimX), rdimv(input.dimV), rdime(input.dimE), rdimfv(input.dimFv), rdimfe(input.dimFe),
       numSamplesX(input.sampX), numSamplesV(input.sampV), numSamplesE(input.sampE), use_sns(input.SNS),
       hyperreduce(input.hyperreduce), hyperreduce_prep(input.hyperreduce_prep), offsetInit(input.useOffset),
-      RHSbasis(input.RHSbasis), useGramSchmidt(input.GramSchmidt), lhoper(input.FOMoper), 
+      RHSbasis(input.RHSbasis), useGramSchmidt(input.GramSchmidt), lhoper(input.FOMoper),
       RK2AvgFormulation(input.RK2AvgSolver), basename(*input.basename),
       mergeXV(input.mergeXV), useXV(input.useXV), useVX(input.useVX), Voffset(!input.useXV && !input.useVX && !input.mergeXV),
       energyFraction_X(input.energyFraction_X), use_qdeim(input.qdeim)
@@ -1398,18 +1398,15 @@ void ROM_Basis::ReadSolutionBases(const int window)
         basisV = basisX;
     }
 
-    if (hyperreduce)
+    if (!use_sns)
     {
-        if (!use_sns)
-        {
-            basisFv = ReadBasisROM(rank, basename + "/" + ROMBasisName::Fv + std::to_string(window), tH1size, 0, rdimfv);
-            basisFe = ReadBasisROM(rank, basename + "/" + ROMBasisName::Fe + std::to_string(window), tL2size, 0, rdimfe);
-        }
-        else
-        {
-            basisFv = MultBasisROM(rank, basename + "/" + ROMBasisName::V + std::to_string(window), tH1size, 0, rdimfv, lhoper, 1);
-            basisFe = MultBasisROM(rank, basename + "/" + ROMBasisName::E + std::to_string(window), tL2size, 0, rdimfe, lhoper, 2);
-        }
+        basisFv = ReadBasisROM(rank, basename + "/" + ROMBasisName::Fv + std::to_string(window), tH1size, 0, rdimfv);
+        basisFe = ReadBasisROM(rank, basename + "/" + ROMBasisName::Fe + std::to_string(window), tL2size, 0, rdimfe);
+    }
+    else
+    {
+        basisFv = MultBasisROM(rank, basename + "/" + ROMBasisName::V + std::to_string(window), tH1size, 0, rdimfv, lhoper, 1);
+        basisFe = MultBasisROM(rank, basename + "/" + ROMBasisName::E + std::to_string(window), tL2size, 0, rdimfe, lhoper, 2);
     }
 }
 

--- a/rom/laghos_rom.hpp
+++ b/rom/laghos_rom.hpp
@@ -121,7 +121,7 @@ public:
           H1size(input.H1FESpace->GetVSize()), L2size(input.L2FESpace->GetVSize()),
           X(tH1size), dXdt(tH1size), V(tH1size), dVdt(tH1size), E(tL2size), dEdt(tL2size),
           gfH1(input.H1FESpace), gfL2(input.L2FESpace), offsetInit(input.useOffset), energyFraction(input.energyFraction),
-          energyFraction_X(input.energyFraction_X), sampleF(input.RHSbasis||!input.SNS), lhoper(input.FOMoper), writeSnapshots(input.parameterID >= 0),
+          energyFraction_X(input.energyFraction_X), sns(input.SNS), lhoper(input.FOMoper), writeSnapshots(input.parameterID >= 0),
           parameterID(input.parameterID), basename(*input.basename), Voffset(!input.useXV && !input.useVX && !input.mergeXV),
           useXV(input.useXV), useVX(input.useVX)
     {
@@ -177,7 +177,7 @@ public:
             e_options,
             !staticSVD,
             staticSVD ? BasisFileName(basename, VariableName::E, window, parameterID) : basename + "/" + ROMBasisName::E + std::to_string(window));
-        if (sampleF)
+        if (!sns)
         {
             if (input.randomizedSVD)
             {
@@ -284,7 +284,7 @@ private:
 
     ParGridFunction gfH1, gfL2;
 
-    const bool sampleF;
+    const bool sns;
 
     const bool Voffset;
     const bool useXV;

--- a/rom/laghos_rom.hpp
+++ b/rom/laghos_rom.hpp
@@ -643,8 +643,8 @@ public:
 
     void StepRK2Avg(Vector &S, double &t, double &dt) const;
 
-    void InducedGramSchmidtInitialize(Vector &S);
-    void InducedGramSchmidtFinalize(Vector &S, bool keep_data=false);
+    void ApplyHyperreduction(Vector &S);
+    void PostprocessHyperreduction(Vector &S, bool keep_data=false);
 
     ~ROM_Operator()
     {

--- a/rom/laghos_rom.hpp
+++ b/rom/laghos_rom.hpp
@@ -65,7 +65,7 @@ struct ROM_Options
     bool staticSVD = false; // true: use StaticSVD
     bool useOffset = false; // if true, sample variables minus initial state as an offset
     bool RHSbasis = false; // if true, use bases for nonlinear RHS terms without mass matrix inverses applied
-    bool SNS = false; // if true, use sns
+    bool SNS = false; // if true, use SNS relation to obtain nonlinear RHS bases by multiplying mass matrix to a solution matrix
     double energyFraction = 0.9999; // used for recommending basis sizes, depending on singular values
     double energyFraction_X = 0.9999; // used for recommending basis sizes, depending on singular values
     int window = 0; // Laghos-ROM time window index
@@ -686,7 +686,7 @@ private:
 
     mutable double dt_est_SP = 0.0;
 
-    bool sns1 = false;
+    bool sns1 = false; // Simplify calculation by Eq. (4.4) when using 1st choice of SNS.
     bool noMsolve = false;
     bool useReducedM = false;  // TODO: remove this?
 

--- a/rom/laghos_rom.hpp
+++ b/rom/laghos_rom.hpp
@@ -121,7 +121,7 @@ public:
           H1size(input.H1FESpace->GetVSize()), L2size(input.L2FESpace->GetVSize()),
           X(tH1size), dXdt(tH1size), V(tH1size), dVdt(tH1size), E(tL2size), dEdt(tL2size),
           gfH1(input.H1FESpace), gfL2(input.L2FESpace), offsetInit(input.useOffset), energyFraction(input.energyFraction),
-          energyFraction_X(input.energyFraction_X), sampleF(!input.SNS), lhoper(input.FOMoper), writeSnapshots(input.parameterID >= 0),
+          energyFraction_X(input.energyFraction_X), sampleF(input.RHSbasis||!input.SNS), lhoper(input.FOMoper), writeSnapshots(input.parameterID >= 0),
           parameterID(input.parameterID), basename(*input.basename), Voffset(!input.useXV && !input.useVX && !input.mergeXV),
           useXV(input.useXV), useVX(input.useVX)
     {

--- a/rom/laghos_rom.hpp
+++ b/rom/laghos_rom.hpp
@@ -64,7 +64,8 @@ struct ROM_Options
     bool restore = false; // if true, restore phase
     bool staticSVD = false; // true: use StaticSVD
     bool useOffset = false; // if true, sample variables minus initial state as an offset
-    bool RHSbasis = false; // if true, use bases for nonlinear RHS terms without mass matrix inverses applied
+    bool RHSbasis = true; // if true, use bases for nonlinear RHS terms without mass matrix inverses applied
+    bool SNS = false; // if true, use sns
     double energyFraction = 0.9999; // used for recommending basis sizes, depending on singular values
     double energyFraction_X = 0.9999; // used for recommending basis sizes, depending on singular values
     int window = 0; // Laghos-ROM time window index
@@ -120,7 +121,7 @@ public:
           H1size(input.H1FESpace->GetVSize()), L2size(input.L2FESpace->GetVSize()),
           X(tH1size), dXdt(tH1size), V(tH1size), dVdt(tH1size), E(tL2size), dEdt(tL2size),
           gfH1(input.H1FESpace), gfL2(input.L2FESpace), offsetInit(input.useOffset), energyFraction(input.energyFraction),
-          energyFraction_X(input.energyFraction_X), sampleF(input.RHSbasis), lhoper(input.FOMoper), writeSnapshots(input.parameterID >= 0),
+          energyFraction_X(input.energyFraction_X), sampleF(!input.SNS), lhoper(input.FOMoper), writeSnapshots(input.parameterID >= 0),
           parameterID(input.parameterID), basename(*input.basename), Voffset(!input.useXV && !input.useVX && !input.mergeXV),
           useXV(input.useXV), useVX(input.useVX)
     {
@@ -497,7 +498,7 @@ public:
         return BEsp;
     }
 
-    void ComputeReducedMatrices();
+    void ComputeReducedMatrices(bool sns1);
 
     MPI_Comm comm;
 
@@ -506,6 +507,8 @@ private:
     const bool hyperreduce_prep;
     const bool offsetInit;
     const bool RHSbasis;
+    const bool use_sns;
+    hydrodynamics::LagrangianHydroOperator *lhoper; // for SNS
     const bool useGramSchmidt;
     int rdimx, rdimv, rdime, rdimfv, rdimfe;
     int nprocs, rank, rowOffsetH1, rowOffsetL2;
@@ -683,8 +686,9 @@ private:
 
     mutable double dt_est_SP = 0.0;
 
-    bool useReducedMv = false;  // TODO: remove this?
-    bool useReducedMe = false;  // TODO: remove this?
+    bool sns1 = false;
+    bool noMsolve = false;
+    bool useReducedM = false;  // TODO: remove this?
 
     DenseMatrix invMvROM, invMeROM;
 

--- a/rom/laghos_rom.hpp
+++ b/rom/laghos_rom.hpp
@@ -64,7 +64,7 @@ struct ROM_Options
     bool restore = false; // if true, restore phase
     bool staticSVD = false; // true: use StaticSVD
     bool useOffset = false; // if true, sample variables minus initial state as an offset
-    bool RHSbasis = true; // if true, use bases for nonlinear RHS terms without mass matrix inverses applied
+    bool RHSbasis = false; // if true, use bases for nonlinear RHS terms without mass matrix inverses applied
     bool SNS = false; // if true, use sns
     double energyFraction = 0.9999; // used for recommending basis sizes, depending on singular values
     double energyFraction_X = 0.9999; // used for recommending basis sizes, depending on singular values
@@ -121,7 +121,7 @@ public:
           H1size(input.H1FESpace->GetVSize()), L2size(input.L2FESpace->GetVSize()),
           X(tH1size), dXdt(tH1size), V(tH1size), dVdt(tH1size), E(tL2size), dEdt(tL2size),
           gfH1(input.H1FESpace), gfL2(input.L2FESpace), offsetInit(input.useOffset), energyFraction(input.energyFraction),
-          energyFraction_X(input.energyFraction_X), sns(input.SNS), lhoper(input.FOMoper), writeSnapshots(input.parameterID >= 0),
+          energyFraction_X(input.energyFraction_X), sns(input.SNS || !input.RHSbasis), lhoper(input.FOMoper), writeSnapshots(input.parameterID >= 0),
           parameterID(input.parameterID), basename(*input.basename), Voffset(!input.useXV && !input.useVX && !input.mergeXV),
           useXV(input.useXV), useVX(input.useVX)
     {

--- a/rom/laghos_rom.hpp
+++ b/rom/laghos_rom.hpp
@@ -65,7 +65,7 @@ struct ROM_Options
     bool staticSVD = false; // true: use StaticSVD
     bool useOffset = false; // if true, sample variables minus initial state as an offset
     bool RHSbasis = false; // if true, use bases for nonlinear RHS terms without mass matrix inverses applied
-    bool SNS = false; // if true, use SNS relation to obtain nonlinear RHS bases by multiplying mass matrix to a solution matrix
+    bool SNS = false; // if true, use SNS relation to obtain nonlinear RHS bases by multiplying mass matrix to a solution matrix. See arXiv 1809.04064.
     double energyFraction = 0.9999; // used for recommending basis sizes, depending on singular values
     double energyFraction_X = 0.9999; // used for recommending basis sizes, depending on singular values
     int window = 0; // Laghos-ROM time window index
@@ -686,7 +686,7 @@ private:
 
     mutable double dt_est_SP = 0.0;
 
-    bool sns1 = false; // Simplify calculation by Eq. (4.4) when using 1st choice of SNS.
+    bool sns1 = false; // Simplify calculation by Eq. (4.4) in arXiv 1809.04064 when using 1st choice of SNS.
     bool noMsolve = false;
     bool useReducedM = false;  // TODO: remove this?
 

--- a/rom/laghos_utils.cpp
+++ b/rom/laghos_utils.cpp
@@ -201,11 +201,9 @@ void SetWindowParameters(Array2D<int> const& twparam, ROM_Options & romOptions)
     romOptions.dimX = twparam(w,0);
     romOptions.dimV = twparam(w,1);
     romOptions.dimE = twparam(w,2);
-    if (romOptions.RHSbasis)
-    {
-        romOptions.dimFv = romOptions.SNS ? romOptions.dimV : twparam(w,3);
-        romOptions.dimFe = romOptions.SNS ? romOptions.dimE : twparam(w,4);
-    }
+    romOptions.dimFv = romOptions.SNS ? romOptions.dimV : twparam(w,3);
+    romOptions.dimFe = romOptions.SNS ? romOptions.dimE : twparam(w,4);
+
     const int oss = (romOptions.SNS) ? 3 : 5;
     romOptions.sampX = twparam(w,oss);
     romOptions.sampV = twparam(w,oss+1);

--- a/rom/laghos_utils.cpp
+++ b/rom/laghos_utils.cpp
@@ -200,8 +200,8 @@ void SetWindowParameters(Array2D<int> const& twparam, ROM_Options & romOptions)
     romOptions.dimE = twparam(w,2);
     if (romOptions.RHSbasis)
     {
-        romOptions.dimFv = twparam(w,3);
-        romOptions.dimFe = twparam(w,4);
+        romOptions.dimFv = romOptions.SNS ? romOptions.dimV : twparam(w,3);
+        romOptions.dimFe = romOptions.SNS ? romOptions.dimE : twparam(w,4);
     }
     const int oss = romOptions.RHSbasis ? 5 : 3;
     romOptions.sampX = twparam(w,oss);

--- a/rom/laghos_utils.cpp
+++ b/rom/laghos_utils.cpp
@@ -105,7 +105,7 @@ int ReadTimeWindows(const int nw, std::string twfile, Array<double>& twep, const
     return 0;
 }
 
-int ReadTimeWindowParameters(const int nw, std::string twfile, Array<double>& twep, Array2D<int>& twparam, double sFactor[], const bool printStatus, const bool rhs)
+int ReadTimeWindowParameters(const int nw, std::string twfile, Array<double>& twep, Array2D<int>& twparam, double sFactor[], const bool printStatus, const bool sns)
 {
     if (printStatus) cout << "Reading time window parameters from file " << twfile << endl;
 
@@ -119,7 +119,7 @@ int ReadTimeWindowParameters(const int nw, std::string twfile, Array<double>& tw
 
     // Parameters to read for each time window:
     // end time, rdimx, rdimv, rdime
-    const int nparamRead = rhs ? 6 : 4; // number of parameters to read for each time window
+    const int nparamRead = sns ? 4 : 6; // number of parameters to read for each time window
 
     // Add 3 more parameters for nsamx, nsamv, nsame
     const int nparam = nparamRead + 3;
@@ -157,16 +157,19 @@ int ReadTimeWindowParameters(const int nw, std::string twfile, Array<double>& tw
 
         // Setting nsamx, nsamv, nsame
         twparam(count, nparamRead-1) = sFactor[0] * twparam(count, 0);
-        twparam(count, nparamRead)   = sFactor[1] * twparam(count, rhs ? 3 : 1);
-        twparam(count, nparamRead+1) = sFactor[2] * twparam(count, rhs ? 4 : 2);
+        twparam(count, nparamRead)   = sFactor[1] * twparam(count, sns ? 1 : 3);
+        twparam(count, nparamRead+1) = sFactor[2] * twparam(count, sns ? 2 : 4);
 
-        if (rhs && printStatus) cout << "Using time window " << count << " with end time " << twep[count] << ", rdimx " << twparam(count,0)
-                                         << ", rdimv " << twparam(count,1) << ", rdime " << twparam(count,2) << ", rdimfv " << twparam(count,3)
-                                         << ", rdimfe " << twparam(count,4) << ", nsamx " << twparam(count,5)
-                                         << ", nsamv " << twparam(count,6) << ", nsame " << twparam(count,7) << endl;
-        else if (printStatus) cout << "Using time window " << count << " with end time " << twep[count] << ", rdimx " << twparam(count,0)
-                                       << ", rdimv " << twparam(count,1) << ", rdime " << twparam(count,2) << ", nsamx " << twparam(count,3)
-                                       << ", nsamv " << twparam(count,4) << ", nsame " << twparam(count,5) << endl;
+        if (printStatus)
+        {
+            if (sns) cout << "Using time window " << count << " with end time " << twep[count] << ", rdimx " << twparam(count,0)
+                              << ", rdimv " << twparam(count,1) << ", rdime " << twparam(count,2) << ", nsamx " << twparam(count,3)
+                              << ", nsamv " << twparam(count,4) << ", nsame " << twparam(count,5) << endl;
+            else cout << "Using time window " << count << " with end time " << twep[count] << ", rdimx " << twparam(count,0)
+                          << ", rdimv " << twparam(count,1) << ", rdime " << twparam(count,2) << ", rdimfv " << twparam(count,3)
+                          << ", rdimfe " << twparam(count,4) << ", nsamx " << twparam(count,5)
+                          << ", nsamv " << twparam(count,6) << ", nsame " << twparam(count,7) << endl;
+        }
 
         count++;
     }
@@ -203,7 +206,7 @@ void SetWindowParameters(Array2D<int> const& twparam, ROM_Options & romOptions)
         romOptions.dimFv = romOptions.SNS ? romOptions.dimV : twparam(w,3);
         romOptions.dimFe = romOptions.SNS ? romOptions.dimE : twparam(w,4);
     }
-    const int oss = romOptions.RHSbasis ? 5 : 3;
+    const int oss = (romOptions.SNS) ? 3 : 5;
     romOptions.sampX = twparam(w,oss);
     romOptions.sampV = twparam(w,oss+1);
     romOptions.sampE = twparam(w,oss+2);

--- a/rom/merge.cpp
+++ b/rom/merge.cpp
@@ -390,12 +390,14 @@ int main(int argc, char *argv[])
         numBasisWindows = numWindows;
         const int err = ReadTimeWindows(numWindows, twfile, twep, myid == 0);
         MFEM_VERIFY(err == 0, "Error in ReadTimeWindows");
-        outfile_twp.open(outputPath + twpfile);
+        //outfile_twp.open(outputPath + twpfile);
+        outfile_twp.open(outputPath + "twpTemp.csv");
     }
     else if (windowNumSamples > 0) {
         numWindows = 1;
         GetParametricTimeWindows(nset, SNS, outputPath, windowNumSamples, numBasisWindows, twep, offsetAllWindows);
-        outfile_twp.open(outputPath + twpfile);
+        //outfile_twp.open(outputPath + twpfile);
+        outfile_twp.open(outputPath + "twpTemp.csv");
     }
     else {
         numWindows = 1;

--- a/rom/merge.cpp
+++ b/rom/merge.cpp
@@ -448,8 +448,11 @@ int main(int argc, char *argv[])
         }
 
         MFEM_VERIFY(dimX == dimV, "Different sizes for X and V");
-        MFEM_VERIFY(dimFv == dimV, "Different sizes for V and Fv");
-        MFEM_VERIFY(dimFe == dimE, "Different sizes for E and Fe");
+        if (!SNS)
+        {
+            MFEM_VERIFY(dimFv == dimV, "Different sizes for V and Fv");
+            MFEM_VERIFY(dimFe == dimE, "Different sizes for E and Fe");
+        }
 
         int totalSnapshotSize = snapshotSize[0];
         int totalSnapshotSizeFv = snapshotSizeFv[0];

--- a/rom/merge.cpp
+++ b/rom/merge.cpp
@@ -447,9 +447,9 @@ int main(int argc, char *argv[])
             }
         }
 
-        //MFEM_VERIFY(dimX == dimV, "Different sizes for X and V");
-        //MFEM_VERIFY(dimFv == dimV, "Different sizes for V and Fv");
-        //MFEM_VERIFY(dimFe == dimE, "Different sizes for E and Fe");
+        MFEM_VERIFY(dimX == dimV, "Different sizes for X and V");
+        MFEM_VERIFY(dimFv == dimV, "Different sizes for V and Fv");
+        MFEM_VERIFY(dimFe == dimE, "Different sizes for E and Fe");
 
         int totalSnapshotSize = snapshotSize[0];
         int totalSnapshotSizeFv = snapshotSizeFv[0];

--- a/rom/merge.cpp
+++ b/rom/merge.cpp
@@ -334,6 +334,7 @@ int main(int argc, char *argv[])
     bool SNS = false;
     const char *basename = "";
     const char *twfile = "tw.csv";
+    const char *twpfile = "twp.csv";
 
     OptionsParser args(argc, argv);
     args.AddOption(&nset, "-nset", "--numsets", "Number of sample sets to merge.");
@@ -353,6 +354,8 @@ int main(int argc, char *argv[])
                    "Name of the sub-folder to dump files within the run directory");
     args.AddOption(&twfile, "-tw", "--timewindowfilename",
                    "Name of the CSV file defining offline time windows");
+    args.AddOption(&twpfile, "-twp", "--timewindowparamfilename",
+                   "Name of the CSV file defining online time window parameters");
 
     args.Parse();
     if (!args.Good())
@@ -387,12 +390,12 @@ int main(int argc, char *argv[])
         numBasisWindows = numWindows;
         const int err = ReadTimeWindows(numWindows, twfile, twep, myid == 0);
         MFEM_VERIFY(err == 0, "Error in ReadTimeWindows");
-        outfile_twp.open(outputPath + "/twpTemp.csv");
+        outfile_twp.open(outputPath + twpfile);
     }
     else if (windowNumSamples > 0) {
         numWindows = 1;
         GetParametricTimeWindows(nset, SNS, outputPath, windowNumSamples, numBasisWindows, twep, offsetAllWindows);
-        outfile_twp.open(outputPath + "/twpTemp.csv");
+        outfile_twp.open(outputPath + twpfile);
     }
     else {
         numWindows = 1;

--- a/rom/merge.cpp
+++ b/rom/merge.cpp
@@ -331,6 +331,7 @@ int main(int argc, char *argv[])
     bool useOffset = false;
     const char *offsetType = "previous";
     bool rhsBasis = false;
+    bool SNS = false;
     const char *basename = "";
     const char *twfile = "tw.csv";
 
@@ -346,6 +347,8 @@ int main(int argc, char *argv[])
                    "Offset type for initializing ROM windows.");
     args.AddOption(&rhsBasis, "-rhs", "--rhsbasis", "-no-rhs", "--no-rhsbasis",
                    "Enable or disable merging of RHS bases for Fv and Fe.");
+    args.AddOption(&SNS, "-romsns", "--romsns", "-no-romsns", "--no-romsns",
+                   "Enable or disable SNS in hyperreduction on Fv and Fe");
     args.AddOption(&basename, "-o", "--outputfilename",
                    "Name of the sub-folder to dump files within the run directory");
     args.AddOption(&twfile, "-tw", "--timewindowfilename",
@@ -367,6 +370,7 @@ int main(int argc, char *argv[])
         outputPath += "/" + std::string(basename);
     }
 
+    MFEM_VERIFY(!(rhsBasis && SNS), "-rhs and -romsns cannot both be set")
     MFEM_VERIFY(windowNumSamples == 0 || numWindows == 0, "-nwinsamp and -nwin cannot both be set");
     MFEM_VERIFY(windowNumSamples >= 0, "Negative window");
     MFEM_VERIFY(windowOverlapSamples >= 0, "Negative window overlap");
@@ -406,7 +410,7 @@ int main(int argc, char *argv[])
     split_line(line, words);
     MFEM_VERIFY(std::stoi(words[0]) == useOffset, "-romos option does not match record.");
     MFEM_VERIFY(std::stoi(words[1]) == trueOffsetType, "-romostype option does not match record.");
-    MFEM_VERIFY(std::stoi(words[2]) == rhsBasis, "-romsrhs option does not match record.");
+    MFEM_VERIFY(std::stoi(words[2]) == SNS, "-romsns option does not match record.");
     MFEM_VERIFY(std::stoi(words[3]) == numWindows, "-nwin option does not match record.");
     MFEM_VERIFY(std::strcmp(words[4].c_str(), twfile) == 0, "-tw option does not match record.");
     infile_offlineParam.close();
@@ -438,9 +442,9 @@ int main(int argc, char *argv[])
             }
         }
 
-        MFEM_VERIFY(dimX == dimV, "Different sizes for X and V");
-        MFEM_VERIFY(dimFv == dimV, "Different sizes for V and Fv");
-        MFEM_VERIFY(dimFe == dimE, "Different sizes for E and Fe");
+        //MFEM_VERIFY(dimX == dimV, "Different sizes for X and V");
+        //MFEM_VERIFY(dimFv == dimV, "Different sizes for V and Fv");
+        //MFEM_VERIFY(dimFe == dimE, "Different sizes for E and Fe");
 
         int totalSnapshotSize = snapshotSize[0];
         int totalSnapshotSizeFv = snapshotSizeFv[0];

--- a/rom/merge.cpp
+++ b/rom/merge.cpp
@@ -488,12 +488,11 @@ int main(int argc, char *argv[])
 
             if (myid == 0 && usingWindows)
             {
-                outfile_twp << twep[basisWindow] << ", ";
-                if (!SNS)
-                    outfile_twp << cutoff[0] << ", " << cutoff[1] << ", " << cutoff[2] << ", "
-                                << cutoff[3] << ", " << cutoff[4] << "\n";
+                outfile_twp << twep[basisWindow] << ", " << cutoff[0] << ", " << cutoff[1] << ", " << cutoff[2];
+                if (SNS)
+                    outfile_twp << "\n";
                 else
-                    outfile_twp << cutoff[0] << ", " << cutoff[1] << ", " << cutoff[2] << "\n";
+                    outfile_twp << ", " << cutoff[3] << ", " << cutoff[4] << "\n";
             }
         }
     }

--- a/rom/merge.cpp
+++ b/rom/merge.cpp
@@ -369,7 +369,7 @@ int main(int argc, char *argv[])
         args.PrintOptions(cout);
     }
     std::string outputPath = "run";
-    if (basename != "") {
+    if (std::string(basename) != "") {
         outputPath += "/" + std::string(basename);
     }
 

--- a/rom/merge.cpp
+++ b/rom/merge.cpp
@@ -390,14 +390,14 @@ int main(int argc, char *argv[])
         numBasisWindows = numWindows;
         const int err = ReadTimeWindows(numWindows, twfile, twep, myid == 0);
         MFEM_VERIFY(err == 0, "Error in ReadTimeWindows");
-        //outfile_twp.open(outputPath + twpfile);
-        outfile_twp.open(outputPath + "twpTemp.csv");
+        //outfile_twp.open(outputPath + "/" + std::string(twpfile));
+        outfile_twp.open(outputPath + "/twpTemp.csv");
     }
     else if (windowNumSamples > 0) {
         numWindows = 1;
         GetParametricTimeWindows(nset, SNS, outputPath, windowNumSamples, numBasisWindows, twep, offsetAllWindows);
-        //outfile_twp.open(outputPath + twpfile);
-        outfile_twp.open(outputPath + "twpTemp.csv");
+        //outfile_twp.open(outputPath + "/" + std::string(twpfile));
+        outfile_twp.open(outputPath + "/twpTemp.csv");
     }
     else {
         numWindows = 1;

--- a/rom/setup.sh
+++ b/rom/setup.sh
@@ -23,13 +23,10 @@ mkdir -p $LIB_DIR
 # Install HYPRE
 cd $LIB_DIR
 if [ ! -d "hypre" ]; then
-  wget https://computing.llnl.gov/projects/hypre-scalable-linear-solvers-multigrid-methods/download/hypre-2.11.2.tar.gz
-  tar -zxvf hypre-2.11.2.tar.gz
-  cd hypre-2.11.2/src
+  git clone https://github.com/hypre-space/hypre.git
+  cd hypre/src
   ./configure --disable-fortran
   make -j
-  cd $LIB_DIR
-  mv hypre-2.11.2 hypre
 fi
 
 # Install PARMETIS 4.0.3
@@ -65,8 +62,6 @@ fi
 cd $LIB_DIR
 if [ ! -d "libROM" ]; then
   git clone https://github.com/LLNL/libROM.git
-  cd libROM
-  ./scripts/laghos_compile.sh
 fi
 cd libROM
 git pull

--- a/rom/tests/gresho-vortices/gresho-vortices-time-window.sh
+++ b/rom/tests/gresho-vortices/gresho-vortices-time-window.sh
@@ -5,11 +5,11 @@ case $subTestNum in
     $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -offline -ef 0.9999 -writesol -romsvds -nwin 4 -tw "$BASE_DIR"/tests/gresho-vortices/gresho-vortices-time-window.csv -sdim 800 -romsrhs
     ;;
   2)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -online -soldiff -romsvds -nwin 4 -twp twpTemp.csv -romsrhs
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -online -romgs -soldiff -romsvds -nwin 4 -twp twpTemp.csv -romsrhs 
     ;;
   3)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -online -romhrprep -romsvds -sfacx 50 -sfacv 50 -sface 50 -nwin 4 -twp twpTemp.csv -romsrhs
-    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -online -romhr -romsvds -sfacx 50 -sfacv 50 -sface 50 -nwin 4 -twp twpTemp.csv -romsrhs
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -online -romgs -romhrprep -romsvds -sfacx 50 -sfacv 50 -sface 50 -nwin 4 -twp twpTemp.csv -romsrhs
+    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -online -romgs -romhr -romsvds -sfacx 50 -sfacv 50 -sface 50 -nwin 4 -twp twpTemp.csv -romsrhs
     ;;
   4)
     $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -restore -nwin 4 -twp twpTemp.csv -soldiff -romsrhs

--- a/rom/tests/gresho-vortices/gresho-vortices-time-window.sh
+++ b/rom/tests/gresho-vortices/gresho-vortices-time-window.sh
@@ -2,16 +2,16 @@ NUM_PARALLEL_PROCESSORS=8
 testNames=(offline online romhr restore)
 case $subTestNum in
   1)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -offline -ef 0.9999 -writesol -romsvds -nwin 4 -tw "$BASE_DIR"/tests/gresho-vortices/gresho-vortices-time-window.csv -sdim 800
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -offline -ef 0.9999 -writesol -romsvds -nwin 4 -tw "$BASE_DIR"/tests/gresho-vortices/gresho-vortices-time-window.csv -sdim 800 -romsrhs
     ;;
   2)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -online -soldiff -romsvds -nwin 4 -twp twpTemp.csv
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -online -soldiff -romsvds -nwin 4 -twp twpTemp.csv -romsrhs
     ;;
   3)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -online -romhrprep -romsvds -sfacx 50 -sfacv 50 -sface 50 -nwin 4 -twp twpTemp.csv
-    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -online -romhr -romsvds -sfacx 50 -sfacv 50 -sface 50 -nwin 4 -twp twpTemp.csv
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -online -romhrprep -romsvds -sfacx 50 -sfacv 50 -sface 50 -nwin 4 -twp twpTemp.csv -romsrhs
+    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -online -romhr -romsvds -sfacx 50 -sfacv 50 -sface 50 -nwin 4 -twp twpTemp.csv -romsrhs
     ;;
   4)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -restore -nwin 4 -twp twpTemp.csv -soldiff
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.1 -s 7 -restore -nwin 4 -twp twpTemp.csv -soldiff -romsrhs
     ;;
 esac

--- a/rom/tests/gresho-vortices/gresho-vortices.sh
+++ b/rom/tests/gresho-vortices/gresho-vortices.sh
@@ -9,7 +9,7 @@ case $subTestNum in
     ;;
   3)
     $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -romgs -rdimx 4 -rdimv 20 -rdime 16 -rdimfv 34 -rdimfe 39 -romhrprep -nsamx 18 -nsamv 3401 -nsame 128 -romsrhs
-    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -romgs -rdimx 4 -rdimv 20 -rdime 16 -rdimefv 34 -rdimfe 39 -romhr -nsamx 18 -nsamv 3401 -nsame 128 -romsrhs
+    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -romgs -rdimx 4 -rdimv 20 -rdime 16 -rdimfv 34 -rdimfe 39 -romhr -nsamx 18 -nsamv 3401 -nsame 128 -romsrhs
     ;;
   4)
     $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -romgs -rdimx 4 -rdimv 20 -rdime 16 -rdimfv 34 -rdimfe 39 -romhrprep -sfacv 40 -sface 40 -qdeim -romsrhs

--- a/rom/tests/gresho-vortices/gresho-vortices.sh
+++ b/rom/tests/gresho-vortices/gresho-vortices.sh
@@ -2,20 +2,20 @@ NUM_PARALLEL_PROCESSORS=8
 testNames=(offline online romhr qdeim restore)
 case $subTestNum in
   1)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -offline -writesol -romsvds
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -offline -writesol -romsvds -romsrhs
     ;;
   2)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -rdimx 4 -rdimv 20 -rdime 16 -soldiff
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -rdimx 4 -rdimv 20 -rdime 16 -soldiff -romsrhs
     ;;
   3)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -rdimx 4 -rdimv 20 -rdime 16 -romhrprep -nsamx 18 -nsamv 3401 -nsame 128
-    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -rdimx 4 -rdimv 20 -rdime 16 -romhr -nsamx 18 -nsamv 3401 -nsame 128
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -rdimx 4 -rdimv 20 -rdime 16 -romhrprep -nsamx 18 -nsamv 3401 -nsame 128 -romsrhs
+    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -rdimx 4 -rdimv 20 -rdime 16 -romhr -nsamx 18 -nsamv 3401 -nsame 128 -romsrhs
     ;;
   4)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -rdimx 4 -rdimv 20 -rdime 16 -romhrprep -sfacv 40 -sface 40 -qdeim
-    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -rdimx 4 -rdimv 20 -rdime 16 -romhr -sfacv 40 -sface 40 -qdeim
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -rdimx 4 -rdimv 20 -rdime 16 -romhrprep -sfacv 40 -sface 40 -qdeim -romsrhs
+    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -rdimx 4 -rdimv 20 -rdime 16 -romhr -sfacv 40 -sface 40 -qdeim -romsrhs
     ;;
   5)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -restore -rdimx 4 -rdimv 20 -rdime 16 -soldiff
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -restore -rdimx 4 -rdimv 20 -rdime 16 -soldiff -romsrhs
     ;;
 esac

--- a/rom/tests/gresho-vortices/gresho-vortices.sh
+++ b/rom/tests/gresho-vortices/gresho-vortices.sh
@@ -8,12 +8,12 @@ case $subTestNum in
     $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -romgs -rdimx 4 -rdimv 20 -rdime 16 -soldiff -romsrhs
     ;;
   3)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -romgs -rdimx 4 -rdimv 20 -rdime 16 -romhrprep -nsamx 18 -nsamv 3401 -nsame 128 -romsrhs
-    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -romgs -rdimx 4 -rdimv 20 -rdime 16 -romhr -nsamx 18 -nsamv 3401 -nsame 128 -romsrhs
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -romgs -rdimx 4 -rdimv 20 -rdime 16 -rdimfv 34 -rdimfe 39 -romhrprep -nsamx 18 -nsamv 3401 -nsame 128 -romsrhs
+    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -romgs -rdimx 4 -rdimv 20 -rdime 16 -rdimefv 34 -rdimfe 39 -romhr -nsamx 18 -nsamv 3401 -nsame 128 -romsrhs
     ;;
   4)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -romgs -rdimx 4 -rdimv 20 -rdime 16 -romhrprep -sfacv 40 -sface 40 -qdeim -romsrhs
-    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -romgs -rdimx 4 -rdimv 20 -rdime 16 -romhr -sfacv 40 -sface 40 -qdeim -romsrhs
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -romgs -rdimx 4 -rdimv 20 -rdime 16 -rdimfv 34 -rdimfe 39 -romhrprep -sfacv 40 -sface 40 -qdeim -romsrhs
+    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -romgs -rdimx 4 -rdimv 20 -rdime 16 -rdimfv 34 -rdimfe 39 -romhr -sfacv 40 -sface 40 -qdeim -romsrhs
     ;;
   5)
     $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -restore -rdimx 4 -rdimv 20 -rdime 16 -soldiff -romsrhs

--- a/rom/tests/gresho-vortices/gresho-vortices.sh
+++ b/rom/tests/gresho-vortices/gresho-vortices.sh
@@ -5,15 +5,15 @@ case $subTestNum in
     $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -offline -writesol -romsvds -romsrhs
     ;;
   2)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -rdimx 4 -rdimv 20 -rdime 16 -soldiff -romsrhs
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -romgs -rdimx 4 -rdimv 20 -rdime 16 -soldiff -romsrhs
     ;;
   3)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -rdimx 4 -rdimv 20 -rdime 16 -romhrprep -nsamx 18 -nsamv 3401 -nsame 128 -romsrhs
-    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -rdimx 4 -rdimv 20 -rdime 16 -romhr -nsamx 18 -nsamv 3401 -nsame 128 -romsrhs
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -romgs -rdimx 4 -rdimv 20 -rdime 16 -romhrprep -nsamx 18 -nsamv 3401 -nsame 128 -romsrhs
+    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -romgs -rdimx 4 -rdimv 20 -rdime 16 -romhr -nsamx 18 -nsamv 3401 -nsame 128 -romsrhs
     ;;
   4)
-    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -rdimx 4 -rdimv 20 -rdime 16 -romhrprep -sfacv 40 -sface 40 -qdeim -romsrhs
-    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -rdimx 4 -rdimv 20 -rdime 16 -romhr -sfacv 40 -sface 40 -qdeim -romsrhs
+    $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -romgs -rdimx 4 -rdimv 20 -rdime 16 -romhrprep -sfacv 40 -sface 40 -qdeim -romsrhs
+    $LAGHOS_SERIAL -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -online -romgs -rdimx 4 -rdimv 20 -rdime 16 -romhr -sfacv 40 -sface 40 -qdeim -romsrhs
     ;;
   5)
     $LAGHOS -p 4 -m data/square_gresho.mesh -rs 3 -ok 3 -ot 2 -tf 0.12 -s 7 -pa -restore -rdimx 4 -rdimv 20 -rdime 16 -soldiff -romsrhs

--- a/rom/tests/sedov-blast-incremental/sedov-blast-large-tol.sh
+++ b/rom/tests/sedov-blast-incremental/sedov-blast-large-tol.sh
@@ -5,11 +5,11 @@ case $subTestNum in
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -offline -writesol -svtol 1e-3 -romsrhs
     ;;
   2)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 3 -rdimv 7 -rdime 5 -nsamx 12 -nsamv 184 -nsame 30 -soldiff -romsrhs
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 3 -rdimv 7 -rdime 5 -soldiff -romsrhs
     ;;
   3)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 3 -rdimv 7 -rdime 5 -romhrprep -nsamx 4 -nsamv 24 -nsame 32 -romsrhs
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 3 -rdimv 7 -rdime 5 -romhr -nsamx 4 -nsamv 24 -nsame 32 -romsrhs
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 3 -rdimv 7 -rdime 5 -rdimfv 9 -rdimfe 6 -romhrprep -nsamx 4 -nsamv 24 -nsame 32 -romsrhs
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 3 -rdimv 7 -rdime 5 -rdimfv 9 -rdimfe 6 -romhr -nsamx 4 -nsamv 24 -nsame 32 -romsrhs
     ;;
   4)
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -restore -rdimx 3 -rdimv 7 -rdime 5 -soldiff -romsrhs

--- a/rom/tests/sedov-blast-incremental/sedov-blast-large-tol.sh
+++ b/rom/tests/sedov-blast-incremental/sedov-blast-large-tol.sh
@@ -2,16 +2,16 @@ NUM_PARALLEL_PROCESSORS=8
 testNames=(offline online romhr restore)
 case $subTestNum in
   1)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -offline -writesol -svtol 1e-3
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -offline -writesol -svtol 1e-3 -romsrhs
     ;;
   2)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 3 -rdimv 7 -rdime 5 -nsamx 12 -nsamv 184 -nsame 30 -soldiff
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 3 -rdimv 7 -rdime 5 -nsamx 12 -nsamv 184 -nsame 30 -soldiff -romsrhs
     ;;
   3)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 3 -rdimv 7 -rdime 5 -romhrprep -nsamx 4 -nsamv 24 -nsame 32
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 3 -rdimv 7 -rdime 5 -romhr -nsamx 4 -nsamv 24 -nsame 32
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 3 -rdimv 7 -rdime 5 -romhrprep -nsamx 4 -nsamv 24 -nsame 32 -romsrhs
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 3 -rdimv 7 -rdime 5 -romhr -nsamx 4 -nsamv 24 -nsame 32 -romsrhs
     ;;
   4)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -restore -rdimx 3 -rdimv 7 -rdime 5 -soldiff
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -restore -rdimx 3 -rdimv 7 -rdime 5 -soldiff -romsrhs
     ;;
 esac

--- a/rom/tests/sedov-blast-incremental/sedov-blast-large-tol.sh
+++ b/rom/tests/sedov-blast-incremental/sedov-blast-large-tol.sh
@@ -5,11 +5,11 @@ case $subTestNum in
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -offline -writesol -svtol 1e-3 -romsrhs
     ;;
   2)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 3 -rdimv 7 -rdime 5 -nsamx 12 -nsamv 184 -nsame 30 -soldiff -romsrhs
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 3 -rdimv 7 -rdime 5 -nsamx 12 -nsamv 184 -nsame 30 -soldiff -romsrhs
     ;;
   3)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 3 -rdimv 7 -rdime 5 -romhrprep -nsamx 4 -nsamv 24 -nsame 32 -romsrhs
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 3 -rdimv 7 -rdime 5 -romhr -nsamx 4 -nsamv 24 -nsame 32 -romsrhs
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 3 -rdimv 7 -rdime 5 -romhrprep -nsamx 4 -nsamv 24 -nsame 32 -romsrhs
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 3 -rdimv 7 -rdime 5 -romhr -nsamx 4 -nsamv 24 -nsame 32 -romsrhs
     ;;
   4)
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -restore -rdimx 3 -rdimv 7 -rdime 5 -soldiff -romsrhs

--- a/rom/tests/sedov-blast-incremental/sedov-blast-small-tol.sh
+++ b/rom/tests/sedov-blast-incremental/sedov-blast-small-tol.sh
@@ -5,11 +5,11 @@ case $subTestNum in
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -offline -writesol -romsrhs
     ;;
   2)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 7 -rdime 5 -nsamx 12 -nsamv 184 -nsame 30 -soldiff -romsrhs
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 7 -rdime 5 -soldiff -romsrhs
     ;;
   3)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 7 -rdime 5 -romhrprep -nsamx 4 -nsamv 24 -nsame 32 -romsrhs
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 7 -rdime 5 -romhr -nsamx 4 -nsamv 24 -nsame 32 -romsrhs
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 7 -rdime 5 -rdimfv 9 -rdimfe 6 -romhrprep -nsamx 4 -nsamv 24 -nsame 32 -romsrhs
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 7 -rdime 5 -rdimfv 9 -rdimfe 6 -romhr -nsamx 4 -nsamv 24 -nsame 32 -romsrhs
     ;;
   4)
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -restore -rdimx 2 -rdimv 7 -rdime 5 -soldiff -romsrhs

--- a/rom/tests/sedov-blast-incremental/sedov-blast-small-tol.sh
+++ b/rom/tests/sedov-blast-incremental/sedov-blast-small-tol.sh
@@ -5,11 +5,11 @@ case $subTestNum in
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -offline -writesol -romsrhs
     ;;
   2)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 7 -rdime 5 -nsamx 12 -nsamv 184 -nsame 30 -soldiff -romsrhs
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 7 -rdime 5 -nsamx 12 -nsamv 184 -nsame 30 -soldiff -romsrhs
     ;;
   3)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 7 -rdime 5 -romhrprep -nsamx 4 -nsamv 24 -nsame 32 -romsrhs
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 7 -rdime 5 -romhr -nsamx 4 -nsamv 24 -nsame 32 -romsrhs
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 7 -rdime 5 -romhrprep -nsamx 4 -nsamv 24 -nsame 32 -romsrhs
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 7 -rdime 5 -romhr -nsamx 4 -nsamv 24 -nsame 32 -romsrhs
     ;;
   4)
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -restore -rdimx 2 -rdimv 7 -rdime 5 -soldiff -romsrhs

--- a/rom/tests/sedov-blast-incremental/sedov-blast-small-tol.sh
+++ b/rom/tests/sedov-blast-incremental/sedov-blast-small-tol.sh
@@ -2,16 +2,16 @@ NUM_PARALLEL_PROCESSORS=8
 testNames=(offline online romhr restore)
 case $subTestNum in
   1)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -offline -writesol
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -offline -writesol -romsrhs
     ;;
   2)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 7 -rdime 5 -nsamx 12 -nsamv 184 -nsame 30 -soldiff
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 7 -rdime 5 -nsamx 12 -nsamv 184 -nsame 30 -soldiff -romsrhs
     ;;
   3)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 7 -rdime 5 -romhrprep -nsamx 4 -nsamv 24 -nsame 32
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 7 -rdime 5 -romhr -nsamx 4 -nsamv 24 -nsame 32
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 7 -rdime 5 -romhrprep -nsamx 4 -nsamv 24 -nsame 32 -romsrhs
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 7 -rdime 5 -romhr -nsamx 4 -nsamv 24 -nsame 32 -romsrhs
     ;;
   4)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -restore -rdimx 2 -rdimv 7 -rdime 5 -soldiff
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -restore -rdimx 2 -rdimv 7 -rdime 5 -soldiff -romsrhs
     ;;
 esac

--- a/rom/tests/sedov-blast-randomized/sedov-blast-randomized.sh
+++ b/rom/tests/sedov-blast-randomized/sedov-blast-randomized.sh
@@ -2,20 +2,20 @@ NUM_PARALLEL_PROCESSORS=8
 testNames=(offline online romhr qdeim restore)
 case $subTestNum in
   1)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -offline -writesol -romsvdrm -randdimx 2 -randdimv 12 -randdime 6
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -offline -writesol -romsvdrm -randdimx 2 -randdimv 12 -randdime 6 -romsrhs
     ;;
   2)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 11 -rdime 5 -sfacx 6 -sfacv 20 -sface 2 -soldiff
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 11 -rdime 5 -sfacx 6 -sfacv 20 -sface 2 -soldiff -romsrhs
     ;;
   3)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romhrprep -rdimx 2 -rdimv 11 -rdime 5 -sfacx 6 -sfacv 20 -sface 2
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romhr -rdimx 2 -rdimv 11 -rdime 5 -sfacx 6 -sfacv 20 -sface 2
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romhrprep -rdimx 2 -rdimv 11 -rdime 5 -sfacx 6 -sfacv 20 -sface 2 -romsrhs
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romhr -rdimx 2 -rdimv 11 -rdime 5 -sfacx 6 -sfacv 20 -sface 2 -romsrhs
     ;;
   4)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 11 -rdime 5 -romhrprep -qdeim
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 11 -rdime 5 -romhr -qdeim
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 11 -rdime 5 -romhrprep -qdeim -romsrhs
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 11 -rdime 5 -romhr -qdeim -romsrhs
     ;;
   5)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -restore -rdimx 2 -rdimv 11 -rdime 5 -soldiff
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -restore -rdimx 2 -rdimv 11 -rdime 5 -soldiff -romsrhs
     ;;
 esac

--- a/rom/tests/sedov-blast-randomized/sedov-blast-randomized.sh
+++ b/rom/tests/sedov-blast-randomized/sedov-blast-randomized.sh
@@ -5,15 +5,15 @@ case $subTestNum in
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -offline -writesol -romsvdrm -randdimx 2 -randdimv 12 -randdime 6 -romsrhs
     ;;
   2)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 11 -rdime 5 -sfacx 6 -sfacv 20 -sface 2 -soldiff -romsrhs
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 11 -rdime 5 -sfacx 6 -sfacv 20 -sface 2 -soldiff -romsrhs
     ;;
   3)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romhrprep -rdimx 2 -rdimv 11 -rdime 5 -sfacx 6 -sfacv 20 -sface 2 -romsrhs
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romhr -rdimx 2 -rdimv 11 -rdime 5 -sfacx 6 -sfacv 20 -sface 2 -romsrhs
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -romhrprep -rdimx 2 -rdimv 11 -rdime 5 -sfacx 6 -sfacv 20 -sface 2 -romsrhs
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -romhr -rdimx 2 -rdimv 11 -rdime 5 -sfacx 6 -sfacv 20 -sface 2 -romsrhs
     ;;
   4)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 11 -rdime 5 -romhrprep -qdeim -romsrhs
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 11 -rdime 5 -romhr -qdeim -romsrhs
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 11 -rdime 5 -romhrprep -qdeim -romsrhs
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 11 -rdime 5 -romhr -qdeim -romsrhs
     ;;
   5)
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -restore -rdimx 2 -rdimv 11 -rdime 5 -soldiff -romsrhs

--- a/rom/tests/sedov-blast-randomized/sedov-blast-randomized.sh
+++ b/rom/tests/sedov-blast-randomized/sedov-blast-randomized.sh
@@ -5,15 +5,15 @@ case $subTestNum in
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -offline -writesol -romsvdrm -randdimx 2 -randdimv 12 -randdime 6 -romsrhs
     ;;
   2)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 11 -rdime 5 -sfacx 6 -sfacv 20 -sface 2 -soldiff -romsrhs
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 11 -rdime 5 -soldiff -romsrhs
     ;;
   3)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -romhrprep -rdimx 2 -rdimv 11 -rdime 5 -sfacx 6 -sfacv 20 -sface 2 -romsrhs
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -romhr -rdimx 2 -rdimv 11 -rdime 5 -sfacx 6 -sfacv 20 -sface 2 -romsrhs
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -romhrprep -rdimx 2 -rdimv 11 -rdime 5 -rdimfv 16 -rdimfe 9 -sfacx 6 -sfacv 20 -sface 2 -romsrhs
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -romhr -rdimx 2 -rdimv 11 -rdime 5 -rdimfv 16 -rdimfe 9 -sfacx 6 -sfacv 20 -sface 2 -romsrhs
     ;;
   4)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 11 -rdime 5 -romhrprep -qdeim -romsrhs
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 11 -rdime 5 -romhr -qdeim -romsrhs
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 11 -rdime 5 -rdimfv 16 -rdimfe 9 -romhrprep -qdeim -romsrhs
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 11 -rdime 5 -rdimfv 16 -rdimfe 9 -romhr -qdeim -romsrhs
     ;;
   5)
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -restore -rdimx 2 -rdimv 11 -rdime 5 -soldiff -romsrhs

--- a/rom/tests/sedov-blast/sedov-blast-time-window.sh
+++ b/rom/tests/sedov-blast/sedov-blast-time-window.sh
@@ -2,16 +2,16 @@ NUM_PARALLEL_PROCESSORS=8
 testNames=(offline online romhr restore)
 case $subTestNum in
   1)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -offline -ef 0.9999 -nwin 4 -tw "$BASE_DIR"/tests/sedov-blast/sedov-blast-time-window.csv -writesol -romsvds
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -offline -ef 0.9999 -nwin 4 -tw "$BASE_DIR"/tests/sedov-blast/sedov-blast-time-window.csv -writesol -romsvds -romsrhs
     ;;
   2)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -nwin 4 -twp twpTemp.csv -soldiff
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -nwin 4 -twp twpTemp.csv -soldiff -romsrhs
     ;;
   3)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romhrprep -nwin 4 -twp twpTemp.csv
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romhr -nwin 4 -twp twpTemp.csv
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romhrprep -nwin 4 -twp twpTemp.csv -romsrhs
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romhr -nwin 4 -twp twpTemp.csv -romsrhs
     ;;
   4)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -restore -nwin 4 -twp twpTemp.csv -soldiff
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -restore -nwin 4 -twp twpTemp.csv -soldiff -romsrhs
     ;;
 esac

--- a/rom/tests/sedov-blast/sedov-blast-time-window.sh
+++ b/rom/tests/sedov-blast/sedov-blast-time-window.sh
@@ -5,11 +5,11 @@ case $subTestNum in
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -offline -ef 0.9999 -nwin 4 -tw "$BASE_DIR"/tests/sedov-blast/sedov-blast-time-window.csv -writesol -romsvds -romsrhs
     ;;
   2)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -nwin 4 -twp twpTemp.csv -soldiff -romsrhs
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -nwin 4 -twp twpTemp.csv -soldiff -romsrhs
     ;;
   3)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romhrprep -nwin 4 -twp twpTemp.csv -romsrhs
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romhr -nwin 4 -twp twpTemp.csv -romsrhs
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -romhrprep -nwin 4 -twp twpTemp.csv -romsrhs
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -romhr -nwin 4 -twp twpTemp.csv -romsrhs
     ;;
   4)
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -restore -nwin 4 -twp twpTemp.csv -soldiff -romsrhs

--- a/rom/tests/sedov-blast/sedov-blast.sh
+++ b/rom/tests/sedov-blast/sedov-blast.sh
@@ -5,15 +5,15 @@ case $subTestNum in
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -offline -writesol -romsvds -romsrhs
     ;;
   2)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 12 -rdime 16 -nsamx 12 -nsamv 184 -nsame 30 -soldiff -romsrhs
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 12 -rdime 16 -nsamx 12 -nsamv 184 -nsame 30 -soldiff -romsrhs
     ;;
   3)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 12 -rdime 16 -romhrprep -nsamx 4 -nsamv 24 -nsame 32 -romsrhs
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 12 -rdime 16 -romhr -nsamx 4 -nsamv 24 -nsame 32 -romsrhs
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 12 -rdime 16 -romhrprep -nsamx 4 -nsamv 24 -nsame 32 -romsrhs
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 12 -rdime 16 -romhr -nsamx 4 -nsamv 24 -nsame 32 -romsrhs
     ;;
   4)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 12 -rdime 16 -romhrprep -qdeim -romsrhs
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 12 -rdime 16 -romhr -qdeim -romsrhs
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 12 -rdime 16 -romhrprep -qdeim -romsrhs
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 12 -rdime 16 -romhr -qdeim -romsrhs
     ;;
   5)
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -restore -rdimx 2 -rdimv 12 -rdime 16 -soldiff -romsrhs

--- a/rom/tests/sedov-blast/sedov-blast.sh
+++ b/rom/tests/sedov-blast/sedov-blast.sh
@@ -5,17 +5,17 @@ case $subTestNum in
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -offline -writesol -romsvds -romsrhs
     ;;
   2)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 12 -rdime 16 -nsamx 12 -nsamv 184 -nsame 30 -soldiff -romsrhs
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 12 -rdime 6 -soldiff -romsrhs
     ;;
   3)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 12 -rdime 16 -romhrprep -nsamx 4 -nsamv 24 -nsame 32 -romsrhs
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 12 -rdime 16 -romhr -nsamx 4 -nsamv 24 -nsame 32 -romsrhs
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 12 -rdime 6 -rdimfv 16 -rdimfe 9 -romhrprep -nsamx 4 -nsamv 24 -nsame 32 -romsrhs
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 12 -rdime 6 -rdimfv 16 -rdimfe 9 -romhr -nsamx 4 -nsamv 24 -nsame 32 -romsrhs
     ;;
   4)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 12 -rdime 16 -romhrprep -qdeim -romsrhs
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 12 -rdime 16 -romhr -qdeim -romsrhs
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 12 -rdime 6 -rdimfv 16 -rdimfe 9 -romhrprep -qdeim -romsrhs
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -romgs -rdimx 2 -rdimv 12 -rdime 6 -rdimfv 16 -rdimfe 9 -romhr -qdeim -romsrhs
     ;;
   5)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -restore -rdimx 2 -rdimv 12 -rdime 16 -soldiff -romsrhs
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -restore -rdimx 2 -rdimv 12 -rdime 6 -soldiff -romsrhs
     ;;
 esac

--- a/rom/tests/sedov-blast/sedov-blast.sh
+++ b/rom/tests/sedov-blast/sedov-blast.sh
@@ -2,20 +2,20 @@ NUM_PARALLEL_PROCESSORS=8
 testNames=(offline online romhr qdeim restore)
 case $subTestNum in
   1)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -offline -writesol -romsvds
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -offline -writesol -romsvds -romsrhs
     ;;
   2)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 12 -rdime 16 -nsamx 12 -nsamv 184 -nsame 30 -soldiff
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 12 -rdime 16 -nsamx 12 -nsamv 184 -nsame 30 -soldiff -romsrhs
     ;;
   3)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 12 -rdime 16 -romhrprep -nsamx 4 -nsamv 24 -nsame 32
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 12 -rdime 16 -romhr -nsamx 4 -nsamv 24 -nsame 32
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 12 -rdime 16 -romhrprep -nsamx 4 -nsamv 24 -nsame 32 -romsrhs
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 12 -rdime 16 -romhr -nsamx 4 -nsamv 24 -nsame 32 -romsrhs
     ;;
   4)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 12 -rdime 16 -romhrprep -qdeim
-    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 12 -rdime 16 -romhr -qdeim
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 12 -rdime 16 -romhrprep -qdeim -romsrhs
+    $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.01 -online -rdimx 2 -rdimv 12 -rdime 16 -romhr -qdeim -romsrhs
     ;;
   5)
-    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -restore -rdimx 2 -rdimv 12 -rdime 16 -soldiff
+    $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.01 -restore -rdimx 2 -rdimv 12 -rdime 16 -soldiff -romsrhs
     ;;
 esac

--- a/rom/tests/taylor-green/taylor-green-time-window.sh
+++ b/rom/tests/taylor-green/taylor-green-time-window.sh
@@ -2,16 +2,16 @@ NUM_PARALLEL_PROCESSORS=8
 testNames=(offline online romhr restore)
 case $subTestNum in
   1)
-    $LAGHOS -p 0 -rs 2 -iv -cfl 0.5 -tf 0.008 -pa -offline -writesol -romsvds -nwin 2 -tw "$BASE_DIR"/tests/taylor-green/taylor-green-time-window.csv
+    $LAGHOS -p 0 -rs 2 -iv -cfl 0.5 -tf 0.008 -pa -offline -writesol -romsvds -nwin 2 -tw "$BASE_DIR"/tests/taylor-green/taylor-green-time-window.csv -romsrhs
     ;;
   2)
-    $LAGHOS -p 0 -rs 2 -iv -cfl 0.5 -tf 0.008 -pa -online -soldiff -nwin 2 -twp twpTemp.csv
+    $LAGHOS -p 0 -rs 2 -iv -cfl 0.5 -tf 0.008 -pa -online -soldiff -nwin 2 -twp twpTemp.csv -romsrhs
     ;;
   3)
-    $LAGHOS -p 0 -rs 2 -iv -cfl 0.5 -tf 0.008 -pa -online -romhrprep -nwin 2 -twp twpTemp.csv
-    $LAGHOS_SERIAL -p 0 -rs 2 -iv -cfl 0.5 -tf 0.008 -pa -online -romhr -nwin 2 -twp twpTemp.csv
+    $LAGHOS -p 0 -rs 2 -iv -cfl 0.5 -tf 0.008 -pa -online -romhrprep -nwin 2 -twp twpTemp.csv -romsrhs
+    $LAGHOS_SERIAL -p 0 -rs 2 -iv -cfl 0.5 -tf 0.008 -pa -online -romhr -nwin 2 -twp twpTemp.csv -romsrhs
     ;;
   4)
-    $LAGHOS -p 0 -rs 2 -iv -cfl 0.5 -tf 0.008 -pa -restore -nwin 2 -twp twpTemp.csv -soldiff
+    $LAGHOS -p 0 -rs 2 -iv -cfl 0.5 -tf 0.008 -pa -restore -nwin 2 -twp twpTemp.csv -soldiff -romsrhs
     ;;
 esac

--- a/rom/tests/taylor-green/taylor-green-time-window.sh
+++ b/rom/tests/taylor-green/taylor-green-time-window.sh
@@ -5,11 +5,11 @@ case $subTestNum in
     $LAGHOS -p 0 -rs 2 -iv -cfl 0.5 -tf 0.008 -pa -offline -writesol -romsvds -nwin 2 -tw "$BASE_DIR"/tests/taylor-green/taylor-green-time-window.csv -romsrhs
     ;;
   2)
-    $LAGHOS -p 0 -rs 2 -iv -cfl 0.5 -tf 0.008 -pa -online -soldiff -nwin 2 -twp twpTemp.csv -romsrhs
+    $LAGHOS -p 0 -rs 2 -iv -cfl 0.5 -tf 0.008 -pa -online -romgs -soldiff -nwin 2 -twp twpTemp.csv -romsrhs
     ;;
   3)
-    $LAGHOS -p 0 -rs 2 -iv -cfl 0.5 -tf 0.008 -pa -online -romhrprep -nwin 2 -twp twpTemp.csv -romsrhs
-    $LAGHOS_SERIAL -p 0 -rs 2 -iv -cfl 0.5 -tf 0.008 -pa -online -romhr -nwin 2 -twp twpTemp.csv -romsrhs
+    $LAGHOS -p 0 -rs 2 -iv -cfl 0.5 -tf 0.008 -pa -online -romgs -romhrprep -nwin 2 -twp twpTemp.csv -romsrhs
+    $LAGHOS_SERIAL -p 0 -rs 2 -iv -cfl 0.5 -tf 0.008 -pa -online -romgs -romhr -nwin 2 -twp twpTemp.csv -romsrhs
     ;;
   4)
     $LAGHOS -p 0 -rs 2 -iv -cfl 0.5 -tf 0.008 -pa -restore -nwin 2 -twp twpTemp.csv -soldiff -romsrhs

--- a/rom/tests/taylor-green/taylor-green.sh
+++ b/rom/tests/taylor-green/taylor-green.sh
@@ -2,16 +2,16 @@ NUM_PARALLEL_PROCESSORS=8
 testNames=(offline online romhr restore)
 case $subTestNum in
   1)
-    $LAGHOS -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -offline -writesol -romsvds
+    $LAGHOS -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -offline -writesol -romsvds -romsrhs
     ;;
   2)
-    $LAGHOS -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -online -rdimx 2 -rdimv 6 -rdime 2 -soldiff
+    $LAGHOS -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -online -rdimx 2 -rdimv 6 -rdime 2 -soldiff -romsrhs
     ;;
   3)
-    $LAGHOS -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -online -rdimx 2 -rdimv 6 -rdime 2 -romhrprep -nsamx 96 -nsamv 320 -nsame 64
-    $LAGHOS_SERIAL -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -online -rdimx 2 -rdimv 6 -rdime 2 -romhr -nsamx 96 -nsamv 320 -nsame 64
+    $LAGHOS -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -online -rdimx 2 -rdimv 6 -rdime 2 -romhrprep -nsamx 96 -nsamv 320 -nsame 64 -romsrhs
+    $LAGHOS_SERIAL -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -online -rdimx 2 -rdimv 6 -rdime 2 -romhr -nsamx 96 -nsamv 320 -nsame 64 -romsrhs
     ;;
   4)
-    $LAGHOS -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -restore -rdimx 2 -rdimv 6 -rdime 2 -soldiff
+    $LAGHOS -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -restore -rdimx 2 -rdimv 6 -rdime 2 -soldiff -romsrhs
     ;;
 esac

--- a/rom/tests/taylor-green/taylor-green.sh
+++ b/rom/tests/taylor-green/taylor-green.sh
@@ -5,11 +5,11 @@ case $subTestNum in
     $LAGHOS -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -offline -writesol -romsvds -romsrhs
     ;;
   2)
-    $LAGHOS -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -online -rdimx 2 -rdimv 6 -rdime 2 -soldiff -romsrhs
+    $LAGHOS -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -online -romgs -rdimx 2 -rdimv 6 -rdime 2 -soldiff -romsrhs
     ;;
   3)
-    $LAGHOS -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -online -rdimx 2 -rdimv 6 -rdime 2 -romhrprep -nsamx 96 -nsamv 320 -nsame 64 -romsrhs
-    $LAGHOS_SERIAL -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -online -rdimx 2 -rdimv 6 -rdime 2 -romhr -nsamx 96 -nsamv 320 -nsame 64 -romsrhs
+    $LAGHOS -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -online -romgs -rdimx 2 -rdimv 6 -rdime 2 -romhrprep -nsamx 96 -nsamv 320 -nsame 64 -romsrhs
+    $LAGHOS_SERIAL -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -online -romgs -rdimx 2 -rdimv 6 -rdime 2 -romhr -nsamx 96 -nsamv 320 -nsame 64 -romsrhs
     ;;
   4)
     $LAGHOS -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -restore -rdimx 2 -rdimv 6 -rdime 2 -soldiff -romsrhs

--- a/rom/tests/taylor-green/taylor-green.sh
+++ b/rom/tests/taylor-green/taylor-green.sh
@@ -8,8 +8,8 @@ case $subTestNum in
     $LAGHOS -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -online -romgs -rdimx 2 -rdimv 6 -rdime 2 -soldiff -romsrhs
     ;;
   3)
-    $LAGHOS -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -online -romgs -rdimx 2 -rdimv 6 -rdime 2 -romhrprep -nsamx 96 -nsamv 320 -nsame 64 -romsrhs
-    $LAGHOS_SERIAL -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -online -romgs -rdimx 2 -rdimv 6 -rdime 2 -romhr -nsamx 96 -nsamv 320 -nsame 64 -romsrhs
+    $LAGHOS -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -online -romgs -rdimx 2 -rdimv 6 -rdime 2 -rdimfv 9 -rdimfe 11 -romhrprep -nsamx 96 -nsamv 320 -nsame 64 -romsrhs
+    $LAGHOS_SERIAL -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -online -romgs -rdimx 2 -rdimv 6 -rdime 2 -rdimfv 9 -rdimfe 11 -romhr -nsamx 96 -nsamv 320 -nsame 64 -romsrhs
     ;;
   4)
     $LAGHOS -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -restore -rdimx 2 -rdimv 6 -rdime 2 -soldiff -romsrhs

--- a/rom/tests/triple-point/absolute-triple-point.sh
+++ b/rom/tests/triple-point/absolute-triple-point.sh
@@ -11,7 +11,7 @@ case $subTestNum in
     $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.2 -cfl 0.05 -pa -offline -writesol -romsvds -rostype load
     ;;
   2)
-    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.2 -cfl 0.05 -pa -online -rdimx 3 -rdimv 7 -rdime 5 -romhrprep -nsamx 6 -nsamv 448 -nsame 10 -rostype load
-    $LAGHOS_SERIAL -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.2 -cfl 0.05 -pa -online -rdimx 3 -rdimv 7 -rdime 5 -romhr -nsamx 6 -nsamv 448 -nsame 10 -rostype load
+    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.2 -cfl 0.05 -pa -online -romgs -rdimx 3 -rdimv 7 -rdime 5 -romhrprep -nsamx 6 -nsamv 448 -nsame 10 -rostype load
+    $LAGHOS_SERIAL -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.2 -cfl 0.05 -pa -online -romgs -rdimx 3 -rdimv 7 -rdime 5 -romhr -nsamx 6 -nsamv 448 -nsame 10 -rostype load
     ;;
 esac

--- a/rom/tests/triple-point/triple-point-time-window.sh
+++ b/rom/tests/triple-point/triple-point-time-window.sh
@@ -2,16 +2,16 @@ NUM_PARALLEL_PROCESSORS=8
 testNames=(offline online romhr restore)
 case $subTestNum in
   1)
-    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -offline -writesol -romsvds -ef 0.9999 -nwin 4 -tw "$BASE_DIR"/tests/triple-point/triple-point-time-window.csv
+    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -offline -writesol -romsvds -ef 0.9999 -nwin 4 -tw "$BASE_DIR"/tests/triple-point/triple-point-time-window.csv -romsrhs
     ;;
   2)
-    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -soldiff -nwin 4 -twp twpTemp.csv
+    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -soldiff -nwin 4 -twp twpTemp.csv -romsrhs
     ;;
   3)
-    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -nwin 4 -romhrprep -twp twpTemp.csv
-    $LAGHOS_SERIAL -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -nwin 4 -romhr -twp twpTemp.csv
+    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -nwin 4 -romhrprep -twp twpTemp.csv -romsrhs
+    $LAGHOS_SERIAL -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -nwin 4 -romhr -twp twpTemp.csv -romsrhs
     ;;
   4)
-    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -restore -nwin 4 -twp twpTemp.csv -soldiff
+    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -restore -nwin 4 -twp twpTemp.csv -soldiff -romsrhs
     ;;
 esac

--- a/rom/tests/triple-point/triple-point-time-window.sh
+++ b/rom/tests/triple-point/triple-point-time-window.sh
@@ -5,11 +5,11 @@ case $subTestNum in
     $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -offline -writesol -romsvds -ef 0.9999 -nwin 4 -tw "$BASE_DIR"/tests/triple-point/triple-point-time-window.csv -romsrhs
     ;;
   2)
-    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -soldiff -nwin 4 -twp twpTemp.csv -romsrhs
+    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -romgs -soldiff -nwin 4 -twp twpTemp.csv -romsrhs
     ;;
   3)
-    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -nwin 4 -romhrprep -twp twpTemp.csv -romsrhs
-    $LAGHOS_SERIAL -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -nwin 4 -romhr -twp twpTemp.csv -romsrhs
+    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -romgs -nwin 4 -romhrprep -twp twpTemp.csv -romsrhs
+    $LAGHOS_SERIAL -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -romgs -nwin 4 -romhr -twp twpTemp.csv -romsrhs
     ;;
   4)
     $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -restore -nwin 4 -twp twpTemp.csv -soldiff -romsrhs

--- a/rom/tests/triple-point/triple-point.sh
+++ b/rom/tests/triple-point/triple-point.sh
@@ -5,11 +5,11 @@ case $subTestNum in
     $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -offline -writesol -romsvds -romsrhs
     ;;
   2)
-    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -rdimx 1 -rdimv 4 -rdime 3 -soldiff -romsrhs
+    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -romgs -rdimx 1 -rdimv 4 -rdime 3 -soldiff -romsrhs
     ;;
   3)
-    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -rdimx 1 -rdimv 4 -rdime 3 -romhrprep -nsamx 6 -nsamv 448 -nsame 10 -romsrhs
-    $LAGHOS_SERIAL -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -rdimx 1 -rdimv 4 -rdime 3 -romhr -nsamx 6 -nsamv 448 -nsame 10 -romsrhs
+    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -romgs -rdimx 1 -rdimv 4 -rdime 3 -romhrprep -nsamx 6 -nsamv 448 -nsame 10 -romsrhs
+    $LAGHOS_SERIAL -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -romgs -rdimx 1 -rdimv 4 -rdime 3 -romhr -nsamx 6 -nsamv 448 -nsame 10 -romsrhs
     ;;
   4)
     $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -restore -rdimx 1 -rdimv 4 -rdime 3 -soldiff -romsrhs

--- a/rom/tests/triple-point/triple-point.sh
+++ b/rom/tests/triple-point/triple-point.sh
@@ -2,16 +2,16 @@ NUM_PARALLEL_PROCESSORS=8
 testNames=(offline online romhr restore)
 case $subTestNum in
   1)
-    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -offline -writesol -romsvds
+    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -offline -writesol -romsvds -romsrhs
     ;;
   2)
-    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -rdimx 1 -rdimv 4 -rdime 3 -soldiff
+    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -rdimx 1 -rdimv 4 -rdime 3 -soldiff -romsrhs
     ;;
   3)
-    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -rdimx 1 -rdimv 4 -rdime 3 -romhrprep -nsamx 6 -nsamv 448 -nsame 10
-    $LAGHOS_SERIAL -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -rdimx 1 -rdimv 4 -rdime 3 -romhr -nsamx 6 -nsamv 448 -nsame 10
+    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -rdimx 1 -rdimv 4 -rdime 3 -romhrprep -nsamx 6 -nsamv 448 -nsame 10 -romsrhs
+    $LAGHOS_SERIAL -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -rdimx 1 -rdimv 4 -rdime 3 -romhr -nsamx 6 -nsamv 448 -nsame 10 -romsrhs
     ;;
   4)
-    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -restore -rdimx 1 -rdimv 4 -rdime 3 -soldiff
+    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -restore -rdimx 1 -rdimv 4 -rdime 3 -soldiff -romsrhs
     ;;
 esac

--- a/rom/tests/triple-point/triple-point.sh
+++ b/rom/tests/triple-point/triple-point.sh
@@ -8,8 +8,8 @@ case $subTestNum in
     $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -romgs -rdimx 1 -rdimv 4 -rdime 3 -soldiff -romsrhs
     ;;
   3)
-    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -romgs -rdimx 1 -rdimv 4 -rdime 3 -romhrprep -nsamx 6 -nsamv 448 -nsame 10 -romsrhs
-    $LAGHOS_SERIAL -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -romgs -rdimx 1 -rdimv 4 -rdime 3 -romhr -nsamx 6 -nsamv 448 -nsame 10 -romsrhs
+    $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -romgs -rdimx 1 -rdimv 4 -rdime 3 -rdimfv 5 -rdimfe 4 -romhrprep -nsamx 6 -nsamv 448 -nsame 10 -romsrhs
+    $LAGHOS_SERIAL -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -online -romgs -rdimx 1 -rdimv 4 -rdime 3 -rdimfv 5 -rdimfe 4 -romhr -nsamx 6 -nsamv 448 -nsame 10 -romsrhs
     ;;
   4)
     $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.04 -cfl 0.05 -pa -restore -rdimx 1 -rdimv 4 -rdime 3 -soldiff -romsrhs


### PR DESCRIPTION
This branch is built for a new implementation of the SNS nonlinear model reduction. As the position is governed by the velocity in a linear sense, only nonlinear model reduction for velocity and energy is done. 

A new flag `-romsns` is used to enable/disable SNS. Note that this flag is independent of an existing flag `-romsrhs`, which is always set to be true in the regression tests and numerical results in the LaghosROM paper, irrespective of using snapshot SVD or SNS or nonlinear term basis. Since `-romsrhs` no longer controls the formation of nonlinear term basis and is always used, we should safely remove it in the future.

In the offline phase, `-romsns` controls whether or not to sample nonlinear term snapshots. This is originally controlled by `-romsrhs`. 

In the online phase, with the flag `-romsns`, the nonlinear term bases `basisFv` and `basisFe` are obtained from multiplying `Mv` to `basisV` and `Me` to `basisE` respectively, instead of doing SVD separately.  

Some changes in the procedure of computing the reduced matrices are made. Following the LaghosROM paper, the ROM time marching is composed of three parts. 

1. Solving for the ROM nonlinear terms coordinates
2. Galerkin projection onto ROM solution bases. 
3. Inverting the ROM mass matrices. 

Note that step 2 is not necessary if SNS type I, i.e. not extending the nonlinear term bases, is used, while step 3 is not necessary if induced Gram Schmidt or SNS type I is used. If induced Gram Schmidt is used, the velocity and energy bases are changed, and the Galerkin projection in Step 2 has to be after the induced Gram Schmidt is done. The overall hyper-reduction procedure in the current implementation is listed as follows: 

1. If SNS, multiply the mass matrices to the solution bases to obtain the nonlinear term bases. Otherwise, read the bases. 
2. Perform DEIM on the nonlinear term bases to get the sampling matrices (i.e. for step 1 above)
3. In time marching, given a new time window, 
- perform induced Gram Schmidt (omit if not Gram Schmidt)
- act Galerkin projection on the sampling matrices (i.e. for step 2 above, omit if SNS type I)
- in each step, inverting the ROM mass matrices (i.e. for step 3 above, omit if Gram-Schmidt is done or SNS type I)

After this PR is merged, the following should be considered: 

- Remove `useReducedM` and `RHSbasis` (and the flag `-romsrhs` in the regression tests) if they are no longer used.
- Change the default values of some frequently used tags, e.g. `-romos`, `-romsns`, `-twp`. 