### PR TITLE
Sampling intermediate RK stages

### DIFF
--- a/rom/laghos.cpp
+++ b/rom/laghos.cpp
@@ -1504,8 +1504,8 @@ int main(int argc, char *argv[])
                 samplerTimer.Start();
                 if (rom_sample_stages)
                 {
-                    std::vector<Vector> RKStages = ode_solver_samp->GetRKStages();
-                    std::vector<double> RKTime = ode_solver_samp->GetRKTime();
+                    std::vector<Vector>& RKStages = ode_solver_samp->GetRKStages();
+                    std::vector<double>& RKTime = ode_solver_samp->GetRKTime();
                     MFEM_VERIFY(RKStages.size() == RKStepNumSamples, "Inconsistent number of Runge Kutta stages.");
                     for (int RKidx = 0; RKidx < RKStepNumSamples; ++RKidx)
                     {

--- a/rom/laghos.cpp
+++ b/rom/laghos.cpp
@@ -1521,7 +1521,7 @@ int main(int argc, char *argv[])
                     }
                     else
                     {
-                        endWindow = (sampler->MaxNumSamples() + RKStepNumSamples >= windowNumSamples); 
+                        endWindow = (sampler->MaxNumSamples() + RKStepNumSamples * rom_sample_stages >= windowNumSamples); 
                     }
                 }
 

--- a/rom/laghos.cpp
+++ b/rom/laghos.cpp
@@ -1481,20 +1481,6 @@ int main(int argc, char *argv[])
 
             unique_steps++;
 
-            if (rom_sample_stages) 
-            {
-                // TODO: time this?
-                std::vector<Vector> RKStages = ode_solver_samp->GetRKStages();
-                std::vector<double> RKTime = ode_solver_samp->GetRKTime();
-                MFEM_VERIFY(RKStages.size() == RKStepNumSamples, "Inconsistent number of Runge Kutta stages.");
-                for (int RKidx = 0; RKidx < RKStepNumSamples; ++RKidx)
-                {
-                    sampler->SampleSolution(RKTime[RKidx], dt, RKStages[RKidx]);
-                    if (samplerLast) samplerLast->SampleSolution(RKTime[RKidx], dt, RKStages[RKidx]);
-                    if (mpi.Root()) cout << "Runge-Kutta stage " << RKidx+1 << " sampled" << endl;
-                }
-            }
-
             if (outputTimes) outfile_time << t << "\n";
 
             if (outputSpaceTimeSolution)
@@ -1509,6 +1495,18 @@ int main(int argc, char *argv[])
             {
                 timeLoopTimer.Stop();
                 samplerTimer.Start();
+                if (rom_sample_stages)
+                {
+                    std::vector<Vector> RKStages = ode_solver_samp->GetRKStages();
+                    std::vector<double> RKTime = ode_solver_samp->GetRKTime();
+                    MFEM_VERIFY(RKStages.size() == RKStepNumSamples, "Inconsistent number of Runge Kutta stages.");
+                    for (int RKidx = 0; RKidx < RKStepNumSamples; ++RKidx)
+                    {
+                        sampler->SampleSolution(RKTime[RKidx], dt, RKStages[RKidx]);
+                        if (samplerLast) samplerLast->SampleSolution(RKTime[RKidx], dt, RKStages[RKidx]);
+                        if (mpi.Root()) cout << "Runge-Kutta stage " << RKidx+1 << " sampled" << endl;
+                    }
+                }
                 sampler->SampleSolution(t, last_dt, *S);
 
                 bool endWindow = false;

--- a/rom/laghos.cpp
+++ b/rom/laghos.cpp
@@ -681,9 +681,8 @@ int main(int argc, char *argv[])
         if (rom_build_database) ode_solver_dat = new RK3SSPSolver;
         break;
     case 4:
-        ode_solver = new RK4Solver;
-        rom_sample_stages = false;
-        if (rom_build_database) ode_solver_dat = new RK4Solver;
+        ode_solver = new RK4ROMSolver;
+        if (rom_build_database) ode_solver_dat = new RK4ROMSolver;
         break;
     case 6:
         ode_solver = new RK6Solver;
@@ -1501,7 +1500,7 @@ int main(int argc, char *argv[])
                 {
                     if (numWindows > 0)
                     {
-                        endWindow = (t >= twep[romOptions.window] && romOptions.window < numWindows-1); 
+                        endWindow = (t >= twep[romOptions.window] && romOptions.window < numWindows-1);
                     }
                     else
                     {

--- a/rom/laghos.cpp
+++ b/rom/laghos.cpp
@@ -1509,7 +1509,7 @@ int main(int argc, char *argv[])
                     MFEM_VERIFY(RKStages.size() == RKStepNumSamples, "Inconsistent number of Runge Kutta stages.");
                     for (int RKidx = 0; RKidx < RKStepNumSamples; ++RKidx)
                     {
-                        sampler->SampleSolution(RKTime[RKidx], dt, RKStages[RKidx]);
+                        sampler->SampleSolution(RKTime[RKidx], last_dt, RKStages[RKidx]);
                         if (samplerLast) samplerLast->SampleSolution(RKTime[RKidx], dt, RKStages[RKidx]);
                         if (mpi.Root()) cout << "Runge-Kutta stage " << RKidx+1 << " sampled" << endl;
                     }
@@ -1525,7 +1525,6 @@ int main(int argc, char *argv[])
                     }
                     else
                     {
-                        //endWindow = (sampler->MaxNumSamples() + RKStepNumSamples * rom_sample_stages >= windowNumSamples);
                         endWindow = (sampler->MaxNumSamples() >= windowNumSamples);
                     }
                 }

--- a/rom/laghos.cpp
+++ b/rom/laghos.cpp
@@ -661,6 +661,7 @@ int main(int argc, char *argv[])
 
     // Define the explicit ODE solver used for time integration.
     ODESolver *ode_solver = NULL;
+    int RKStepNumSamples;
     ODESolver *ode_solver_dat = NULL;
     HydroODESolver *ode_solver_samp = NULL;
     switch (ode_solver_type)
@@ -682,6 +683,7 @@ int main(int argc, char *argv[])
         break;
     case 4:
         ode_solver = new RK4ROMSolver(rom_online);
+        if (rom_sample_stages) RKStepNumSamples = 3;
         if (rom_build_database) ode_solver_dat = new RK4ROMSolver(rom_online);
         break;
     case 6:
@@ -691,6 +693,7 @@ int main(int argc, char *argv[])
         break;
     case 7:
         ode_solver = new RK2AvgSolver(rom_online, H1FESpace, L2FESpace);
+        if (rom_sample_stages) RKStepNumSamples = 1;
         if (rom_build_database) ode_solver_dat = new RK2AvgSolver(rom_online, H1FESpace, L2FESpace);
         break;
     default:
@@ -1504,7 +1507,7 @@ int main(int argc, char *argv[])
                     }
                     else
                     {
-                        endWindow = (sampler->MaxNumSamples() >= windowNumSamples); // TODO: think about rom_sample_stages
+                        endWindow = (sampler->MaxNumSamples() + RKStepNumSamples >= windowNumSamples); 
                     }
                 }
 
@@ -1568,6 +1571,7 @@ int main(int argc, char *argv[])
                         sampler->SampleSolution(t, dt, *S);
                         if (rom_sample_stages) ode_solver_samp->SetSampler(sampler);
                     }
+                    else sampler = NULL;
                 }
                 samplerTimer.Stop();
                 timeLoopTimer.Start();

--- a/rom/laghos.cpp
+++ b/rom/laghos.cpp
@@ -1840,7 +1840,7 @@ int main(int argc, char *argv[])
 
         if (solDiff)
         {
-            cout << "solDiff mode " << endl;
+            if (myid == 0) cout << "solDiff mode " << endl;
             PrintDiffParGridFunction(normtype, myid, outputPath + "/Sol_Position", x_gf);
             PrintDiffParGridFunction(normtype, myid, outputPath + "/Sol_Velocity", v_gf);
             PrintDiffParGridFunction(normtype, myid, outputPath + "/Sol_Energy", e_gf);
@@ -1850,7 +1850,7 @@ int main(int argc, char *argv[])
         {
             VisItDataCollection dc(MPI_COMM_WORLD, visit_outputPath, pmesh);
             dc.Load(visitDiffCycle);
-            cout << "Loaded VisIt DC cycle " << dc.GetCycle() << endl;
+            if (myid == 0) cout << "Loaded VisIt DC cycle " << dc.GetCycle() << endl;
 
             ParGridFunction *dcfx = dc.GetParField("Position");
             ParGridFunction *dcfv = dc.GetParField("Velocity");

--- a/rom/laghos.cpp
+++ b/rom/laghos.cpp
@@ -662,6 +662,7 @@ int main(int argc, char *argv[])
     // Define the explicit ODE solver used for time integration.
     ODESolver *ode_solver = NULL;
     ODESolver *ode_solver_dat = NULL;
+    HydroODESolver *ode_solver_samp = NULL;
     switch (ode_solver_type)
     {
     case 1:
@@ -703,6 +704,7 @@ int main(int argc, char *argv[])
         return 3;
     }
 
+    if (rom_sample_stages)  ode_solver_samp = dynamic_cast<HydroODESolver*> (ode_solver);
     romOptions.RK2AvgSolver = (ode_solver_type == 7);
 
     if (fom_data)
@@ -1047,7 +1049,7 @@ int main(int argc, char *argv[])
         romOptions.initial_dt = dt;
         sampler = new ROM_Sampler(romOptions, *S);
         sampler->SampleSolution(0, 0, *S);
-        if (rom_sample_stages) ode_solver->SetSampler(*sampler);
+        if (rom_sample_stages) ode_solver_samp->SetSampler(*sampler);
         samplerTimer.Stop();
     }
 
@@ -1542,7 +1544,7 @@ int main(int argc, char *argv[])
                     if (numWindows == 0 && windowOverlapSamples > 0)
                     {
                         samplerLast = sampler;
-                        if (rom_sample_stages) ode_solver->SetSamplerLast(*samplerLast);
+                        if (rom_sample_stages) ode_solver_samp->SetSamplerLast(*samplerLast);
                     }
                     else
                     {
@@ -1565,7 +1567,7 @@ int main(int argc, char *argv[])
                         romOptions.window = romOptions.window;
                         sampler = new ROM_Sampler(romOptions, *S);
                         sampler->SampleSolution(t, dt, *S);
-                        if (rom_sample_stages) ode_solver->SetSampler(*sampler);
+                        if (rom_sample_stages) ode_solver_samp->SetSampler(*sampler);
                     }
                 }
                 samplerTimer.Stop();
@@ -1589,7 +1591,7 @@ int main(int argc, char *argv[])
 
                     int rdimxprev = romOptions.dimX;
                     int rdimvprev = romOptions.dimV;
-                    int rdimeprev =  romOptions.dimE;
+                    int rdimeprev = romOptions.dimE;
 
                     SetWindowParameters(twparam, romOptions);
                     if (romOptions.hyperreduce)

--- a/rom/laghos.cpp
+++ b/rom/laghos.cpp
@@ -704,7 +704,7 @@ int main(int argc, char *argv[])
         return 3;
     }
 
-    if (rom_sample_stages)  ode_solver_samp = dynamic_cast<HydroODESolver*> (ode_solver);
+    if (rom_sample_stages) ode_solver_samp = dynamic_cast<HydroODESolver*> (ode_solver);
     romOptions.RK2AvgSolver = (ode_solver_type == 7);
 
     if (fom_data)
@@ -1049,7 +1049,7 @@ int main(int argc, char *argv[])
         romOptions.initial_dt = dt;
         sampler = new ROM_Sampler(romOptions, *S);
         sampler->SampleSolution(0, 0, *S);
-        if (rom_sample_stages) ode_solver_samp->SetSampler(*sampler);
+        if (rom_sample_stages) ode_solver_samp->SetSampler(sampler);
         samplerTimer.Stop();
     }
 
@@ -1544,7 +1544,7 @@ int main(int argc, char *argv[])
                     if (numWindows == 0 && windowOverlapSamples > 0)
                     {
                         samplerLast = sampler;
-                        if (rom_sample_stages) ode_solver_samp->SetSamplerLast(*samplerLast);
+                        if (rom_sample_stages) ode_solver_samp->SetSamplerLast(samplerLast);
                     }
                     else
                     {
@@ -1567,7 +1567,7 @@ int main(int argc, char *argv[])
                         romOptions.window = romOptions.window;
                         sampler = new ROM_Sampler(romOptions, *S);
                         sampler->SampleSolution(t, dt, *S);
-                        if (rom_sample_stages) ode_solver_samp->SetSampler(*sampler);
+                        if (rom_sample_stages) ode_solver_samp->SetSampler(sampler);
                     }
                 }
                 samplerTimer.Stop();

--- a/rom/laghos.cpp
+++ b/rom/laghos.cpp
@@ -96,6 +96,11 @@ int main(int argc, char *argv[])
     int myid = mpi.WorldRank();
     int nprocs = mpi.WorldSize();
 
+    MPI_Comm rom_com;
+    int color = (myid != 0);
+    const int status = MPI_Comm_split(MPI_COMM_WORLD, color, myid, &rom_com);
+    MFEM_VERIFY(status == MPI_SUCCESS, "Construction of hyperreduction comm failed");
+
     // Print the banner.
     if (mpi.Root()) {
         display_banner(cout);
@@ -1115,7 +1120,7 @@ int main(int argc, char *argv[])
             for (romOptions.window = numWindows-1; romOptions.window >= 0; --romOptions.window)
             {
                 SetWindowParameters(twparam, romOptions);
-                basis[romOptions.window] = new ROM_Basis(romOptions, MPI_COMM_WORLD, sFactorX, sFactorV);
+                basis[romOptions.window] = new ROM_Basis(romOptions, MPI_COMM_WORLD, rom_com, sFactorX, sFactorV);
                 if (!romOptions.hyperreduce_prep)
                 {
                     romOper[romOptions.window] = new ROM_Operator(romOptions, basis[romOptions.window], rho_coeff, mat_coeff, order_e, source,
@@ -1127,7 +1132,7 @@ int main(int argc, char *argv[])
         }
         else
         {
-            basis[0] = new ROM_Basis(romOptions, MPI_COMM_WORLD, sFactorX, sFactorV, &timesteps);
+            basis[0] = new ROM_Basis(romOptions, MPI_COMM_WORLD, rom_com, sFactorX, sFactorV, &timesteps);
             if (!romOptions.hyperreduce_prep)
             {
                 romOper[0] = new ROM_Operator(romOptions, basis[0], rho_coeff, mat_coeff, order_e, source, visc, vort, cfl, p_assembly,
@@ -1215,7 +1220,7 @@ int main(int argc, char *argv[])
             SetWindowParameters(twparam, romOptions);
         }
 
-        basis[0] = new ROM_Basis(romOptions, MPI_COMM_WORLD, sFactorX, sFactorV);
+        basis[0] = new ROM_Basis(romOptions, MPI_COMM_WORLD, rom_com, sFactorX, sFactorV);
         basis[0]->Init(romOptions, *S);
 
         if (romOptions.mergeXV)
@@ -1277,7 +1282,7 @@ int main(int argc, char *argv[])
                 SetWindowParameters(twparam, romOptions);
                 basis[romOptions.window-1]->LiftROMtoFOM(romS, *S);
                 delete basis[romOptions.window-1];
-                basis[romOptions.window] = new ROM_Basis(romOptions, MPI_COMM_WORLD, sFactorX, sFactorV);
+                basis[romOptions.window] = new ROM_Basis(romOptions, MPI_COMM_WORLD, rom_com, sFactorX, sFactorV);
                 basis[romOptions.window]->Init(romOptions, *S);
 
                 if (romOptions.mergeXV)

--- a/rom/laghos.cpp
+++ b/rom/laghos.cpp
@@ -688,7 +688,7 @@ int main(int argc, char *argv[])
         break;
     case 4:
         if (rom_sample_stages) RKStepNumSamples = 3;
-        ode_solver = new RK4ROMSolver(rom_online);
+        ode_solver = new RK4ROMSolver(rom_online, RKStepNumSamples);
         if (rom_build_database) ode_solver_dat = new RK4ROMSolver();
         break;
     case 6:
@@ -698,7 +698,7 @@ int main(int argc, char *argv[])
         break;
     case 7:
         if (rom_sample_stages) RKStepNumSamples = 1;
-        ode_solver = new RK2AvgSolver(rom_online, H1FESpace, L2FESpace);
+        ode_solver = new RK2AvgSolver(rom_online, H1FESpace, L2FESpace, RKStepNumSamples);
         if (rom_build_database) ode_solver_dat = new RK2AvgSolver(rom_online, H1FESpace, L2FESpace);
         break;
     default:

--- a/rom/laghos.cpp
+++ b/rom/laghos.cpp
@@ -1486,12 +1486,12 @@ int main(int argc, char *argv[])
                 // TODO: time this?
                 std::vector<Vector> RKStages = ode_solver_samp->GetRKStages();
                 std::vector<double> RKTime = ode_solver_samp->GetRKTime();
-                MFEM_VERIFY(RKStages.size() == RKStepNumSamples, "Inconsistent number of RK stages.");
+                MFEM_VERIFY(RKStages.size() == RKStepNumSamples, "Inconsistent number of Runge Kutta stages.");
                 for (int RKidx = 0; RKidx < RKStepNumSamples; ++RKidx)
                 {
                     sampler->SampleSolution(RKTime[RKidx], dt, RKStages[RKidx]);
                     if (samplerLast) samplerLast->SampleSolution(RKTime[RKidx], dt, RKStages[RKidx]);
-                    if (mpi.Root()) cout << "Runge Kutta stage " << RKidx+1 << " sampled" << endl;
+                    if (mpi.Root()) cout << "Runge-Kutta stage " << RKidx+1 << " sampled" << endl;
                 }
             }
 
@@ -1520,7 +1520,8 @@ int main(int argc, char *argv[])
                     }
                     else
                     {
-                        endWindow = (sampler->MaxNumSamples() + RKStepNumSamples * rom_sample_stages >= windowNumSamples); 
+                        //endWindow = (sampler->MaxNumSamples() + RKStepNumSamples * rom_sample_stages >= windowNumSamples);
+                        endWindow = (sampler->MaxNumSamples() >= windowNumSamples);
                     }
                 }
 

--- a/rom/laghos.cpp
+++ b/rom/laghos.cpp
@@ -380,7 +380,7 @@ int main(int argc, char *argv[])
             // The greedy algorithm procedure has ended
             if (myid == 0)
             {
-                std::cout << "The greedy algorithm procedure has completed!" << std::endl;
+                cout << "The greedy algorithm procedure has completed!" << endl;
             }
             return 1;
         }
@@ -1149,6 +1149,7 @@ int main(int argc, char *argv[])
         {
             if (myid == 0)
             {
+                cout << "Writing SP files for window: 0" << endl;
                 basis[0]->writeSP(romOptions, 0);
             }
             for (int curr_window = 1; curr_window < numWindows; curr_window++) {
@@ -1156,6 +1157,7 @@ int main(int argc, char *argv[])
                 basis[curr_window]->computeWindowProjection(*basis[curr_window - 1], romOptions, curr_window);
                 if (myid == 0)
                 {
+                    cout << "Writing SP files for window: " << curr_window << endl;
                     basis[curr_window]->writeSP(romOptions, curr_window);
                 }
             }
@@ -2042,7 +2044,7 @@ int main(int argc, char *argv[])
             // The greedy algorithm procedure has ended
             if (myid == 0)
             {
-                std::cout << "The greedy algorithm procedure has completed!" << std::endl;
+                cout << "The greedy algorithm procedure has completed!" << endl;
             }
             return 1;
         }

--- a/rom/laghos.cpp
+++ b/rom/laghos.cpp
@@ -684,7 +684,7 @@ int main(int argc, char *argv[])
     case 4:
         if (rom_sample_stages) RKStepNumSamples = 3;
         ode_solver = new RK4ROMSolver(rom_online);
-        if (rom_build_database) ode_solver_dat = new RK4ROMSolver(rom_online);
+        if (rom_build_database) ode_solver_dat = new RK4ROMSolver();
         break;
     case 6:
         rom_sample_stages = false;

--- a/rom/laghos.cpp
+++ b/rom/laghos.cpp
@@ -681,8 +681,8 @@ int main(int argc, char *argv[])
         if (rom_build_database) ode_solver_dat = new RK3SSPSolver;
         break;
     case 4:
-        ode_solver = new RK4ROMSolver;
-        if (rom_build_database) ode_solver_dat = new RK4ROMSolver;
+        ode_solver = new RK4ROMSolver(rom_online);
+        if (rom_build_database) ode_solver_dat = new RK4ROMSolver(rom_online);
         break;
     case 6:
         ode_solver = new RK6Solver;

--- a/rom/laghos.cpp
+++ b/rom/laghos.cpp
@@ -1051,7 +1051,6 @@ int main(int argc, char *argv[])
         romOptions.initial_dt = dt;
         sampler = new ROM_Sampler(romOptions, *S);
         sampler->SampleSolution(0, 0, *S);
-        if (rom_sample_stages) ode_solver_samp->SetSampler(sampler);
         samplerTimer.Stop();
     }
 
@@ -1560,7 +1559,6 @@ int main(int argc, char *argv[])
                     if (numWindows == 0 && windowOverlapSamples > 0)
                     {
                         samplerLast = sampler;
-                        if (rom_sample_stages) ode_solver_samp->SetSamplerLast(samplerLast);
                     }
                     else
                     {
@@ -1583,7 +1581,6 @@ int main(int argc, char *argv[])
                         romOptions.window = romOptions.window;
                         sampler = new ROM_Sampler(romOptions, *S);
                         sampler->SampleSolution(t, dt, *S);
-                        if (rom_sample_stages) ode_solver_samp->SetSampler(sampler);
                     }
                     else sampler = NULL;
                 }

--- a/rom/laghos_rom.cpp
+++ b/rom/laghos_rom.cpp
@@ -166,8 +166,7 @@ void printSnapshotTime(std::vector<double> const &tSnap, std::string const path,
     cout << var << " snapshot size: " << tSnap.size() << endl;
     std::ofstream outfile_tSnap(path + var);
 
-    typedef std::numeric_limits< double > dbl;
-    outfile_tSnap.precision(dbl::max_digits10);
+    outfile_tSnap.precision(std::numeric_limits<double>::max_digits10);
 
     for (auto const& i: tSnap)
     {
@@ -1774,7 +1773,7 @@ void ROM_Basis::RestrictFromSampleMesh(const Vector &usp, Vector &u, const bool 
     for (int i=0; i<numSamplesE; ++i)
         (*sE)(i) = useOffset ? usp[(2*size_H1_sp) + s2sp_E[i]] - (*initEsp)(s2sp_E[i]) : usp[(2*size_H1_sp) + s2sp_E[i]];
 
-    // ROM opertion on source: map sample mesh evaluation to reduced coefficients with respect to solution bases
+    // ROM operation on source: map sample mesh evaluation to reduced coefficients with respect to solution bases
     BsinvV->transposeMult(*sV, *rV);
     BsinvE->transposeMult(*sE, *rE);
 

--- a/rom/laghos_rom.cpp
+++ b/rom/laghos_rom.cpp
@@ -1779,6 +1779,7 @@ void ROM_Basis::RestrictFromSampleMesh(const Vector &usp, Vector &u, const bool 
     for (int i=0; i<numSamplesE; ++i)
         (*sE)(i) = useOffset ? usp[(2*size_H1_sp) + s2sp_E[i]] - (*initEsp)(s2sp_E[i]) : usp[(2*size_H1_sp) + s2sp_E[i]];
 
+    // ROM opertion on source: map sample mesh evaluation to reduced coefficients with respect to solution bases
     BsinvV->transposeMult(*sV, *rV);
     BsinvE->transposeMult(*sE, *rE);
 

--- a/rom/laghos_rom.cpp
+++ b/rom/laghos_rom.cpp
@@ -359,9 +359,9 @@ CAROM::Matrix* MultBasisROM(const int rank, const std::string filename, const in
     return S;
 }
 
-ROM_Basis::ROM_Basis(ROM_Options const& input, MPI_Comm comm_, const double sFactorX, const double sFactorV,
+ROM_Basis::ROM_Basis(ROM_Options const& input, MPI_Comm comm_, MPI_Comm rom_com_, const double sFactorX, const double sFactorV,
                      const std::vector<double> *timesteps)
-    : comm(comm_), rdimx(input.dimX), rdimv(input.dimV), rdime(input.dimE), rdimfv(input.dimFv), rdimfe(input.dimFe),
+    : comm(comm_), rom_com(rom_com_), rdimx(input.dimX), rdimv(input.dimV), rdime(input.dimE), rdimfv(input.dimFv), rdimfe(input.dimFe),
       numSamplesX(input.sampX), numSamplesV(input.sampV), numSamplesE(input.sampE),
       numTimeSamplesV(input.tsampV), numTimeSamplesE(input.tsampE),
       use_sns(input.SNS),  offsetInit(input.useOffset),
@@ -1279,11 +1279,6 @@ void ROM_Basis::SetupHyperreduction(ParFiniteElementSpace *H1FESpace, ParFiniteE
 
     ParFiniteElementSpace *sp_H1_space = NULL;
     ParFiniteElementSpace *sp_L2_space = NULL;
-
-    MPI_Comm rom_com;
-    int color = (rank != 0);
-    const int status = MPI_Comm_split(MPI_COMM_WORLD, color, rank, &rom_com);
-    MFEM_VERIFY(status == MPI_SUCCESS, "Construction of hyperreduction comm failed");
 
     // Construct sample mesh
 

--- a/rom/laghos_rom.cpp
+++ b/rom/laghos_rom.cpp
@@ -1285,8 +1285,8 @@ void ROM_Basis::SetupHyperreduction(ParFiniteElementSpace *H1FESpace, ParFiniteE
 
     // This creates sample_pmesh, sp_H1_space, and sp_L2_space only on rank 0.
     CAROM::CreateSampleMesh(*pmesh, H1_space, *H1FESpace, *L2FESpace, *(H1FESpace->FEColl()),
-                     *(L2FESpace->FEColl()), rom_com, sample_dofs_merged,
-                     num_sample_dofs_per_proc_merged, sample_pmesh, sprows, all_sprows, s2sp, st2sp, sp_H1_space, sp_L2_space);
+                            *(L2FESpace->FEColl()), rom_com, sample_dofs_merged,
+                            num_sample_dofs_per_proc_merged, sample_pmesh, sprows, all_sprows, s2sp, st2sp, sp_H1_space, sp_L2_space);
 
     if (rank == 0)
     {

--- a/rom/laghos_rom.cpp
+++ b/rom/laghos_rom.cpp
@@ -165,6 +165,10 @@ void printSnapshotTime(std::vector<double> const &tSnap, std::string const path,
 {
     cout << var << " snapshot size: " << tSnap.size() << endl;
     std::ofstream outfile_tSnap(path + var);
+
+    typedef std::numeric_limits< double > dbl;
+    outfile_tSnap.precision(dbl::max_digits10);
+
     for (auto const& i: tSnap)
     {
         outfile_tSnap << i << endl;

--- a/rom/laghos_rom.hpp
+++ b/rom/laghos_rom.hpp
@@ -497,7 +497,7 @@ class ROM_Basis
     friend class STROM_Basis;
 
 public:
-    ROM_Basis(ROM_Options const& input, MPI_Comm comm_,
+    ROM_Basis(ROM_Options const& input, MPI_Comm comm_, MPI_Comm rom_com_,
               const double sFactorX=1.0, const double sFactorV=1.0,
               const std::vector<double> *timesteps=NULL);
 
@@ -649,6 +649,7 @@ public:
     void ScaleByTemporalBasis(const int t, Vector const& u, Vector &ut);
 
     MPI_Comm comm;
+    MPI_Comm rom_com;
 
     CAROM::Matrix* PiXtransPiV = 0;  // TODO: make this private and use a function to access its mult
     CAROM::Matrix* PiXtransPiX = 0;  // TODO: make this private and use a function to access its mult

--- a/rom/laghos_rom.hpp
+++ b/rom/laghos_rom.hpp
@@ -374,6 +374,11 @@ public:
         return finalNumSamples;
     }
 
+    int GetRank()
+    {
+        return rank;
+    }
+
 private:
     const int H1size;
     const int L2size;

--- a/rom/laghos_timeinteg.cpp
+++ b/rom/laghos_timeinteg.cpp
@@ -45,11 +45,13 @@ void HydroODESolver::Init(TimeDependentOperator &_f)
 void HydroODESolver::SetSampler(ROM_Sampler &_f)
 {
     sampler = dynamic_cast<ROM_Sampler *>(f);
+    MFEM_VERIFY(sampler, "HydroSolvers expect ROM_Sampler.");
 }
 
 void HydroODESolver::SetSamplerLast(ROM_Sampler &_f)
 {
     samplerLast = dynamic_cast<ROM_Sampler *>(f);
+    MFEM_VERIFY(samplerLast, "HydroSolvers expect ROM_Sampler.");
 }
 
 void RK2AvgSolver::Step(Vector &S, double &t, double &dt)
@@ -89,6 +91,7 @@ void RK2AvgSolver::Step(Vector &S, double &t, double &dt)
     // S = S0 + 0.5 * dt * dS_dt;
     add(S0, 0.5 * dt, dS_dt, S);
     if (sampler) sampler->SampleSolution(t, dt, S);
+    else std::cout << "No sample for intemediate RK stages" << endl;
     if (samplerLast) samplerLast->SampleSolution(t, dt, S);
     hydro_oper->ResetQuadratureData();
     hydro_oper->UpdateMesh(S);

--- a/rom/laghos_timeinteg.cpp
+++ b/rom/laghos_timeinteg.cpp
@@ -42,15 +42,15 @@ void HydroODESolver::Init(TimeDependentOperator &_f)
     }
 }
 
-void HydroODESolver::SetSampler(ROM_Sampler &_f)
+void HydroODESolver::SetSampler(ROM_Sampler *f)
 {
-    sampler = dynamic_cast<ROM_Sampler *>(f);
+    sampler = f;
     MFEM_VERIFY(sampler, "HydroSolvers expect ROM_Sampler.");
 }
 
-void HydroODESolver::SetSamplerLast(ROM_Sampler &_f)
+void HydroODESolver::SetSamplerLast(ROM_Sampler *f)
 {
-    samplerLast = dynamic_cast<ROM_Sampler *>(f);
+    samplerLast = f;
     MFEM_VERIFY(samplerLast, "HydroSolvers expect ROM_Sampler.");
 }
 

--- a/rom/laghos_timeinteg.cpp
+++ b/rom/laghos_timeinteg.cpp
@@ -50,8 +50,6 @@ void RK2AvgSolver::Step(Vector &S, double &t, double &dt)
         return;
     }
 
-    RKStages.clear();
-    RKTime.clear();
     const int Vsize = hydro_oper->GetH1VSize();
     Vector V(Vsize), dS_dt(S.Size()), S0(S);
 
@@ -81,8 +79,8 @@ void RK2AvgSolver::Step(Vector &S, double &t, double &dt)
     // S = S0 + 0.5 * dt * dS_dt;
     add(S0, 0.5 * dt, dS_dt, S);
 
-    RKStages.push_back(S);
-    RKTime.push_back(t + 0.5 * dt);
+    RKStages[0] = S;
+    RKTime[0] = t + 0.5 * dt;
 
     hydro_oper->ResetQuadratureData();
     hydro_oper->UpdateMesh(S);
@@ -109,8 +107,6 @@ void RK4ROMSolver::Step(Vector &S, double &t, double &dt)
     // -----+-------------------
     //      | 1/6  1/3  1/3  1/6
 
-    RKStages.clear();
-    RKTime.clear();
     Vector k(S.Size()), y(S.Size()), z(S.Size());
 
     f->SetTime(t);
@@ -119,23 +115,23 @@ void RK4ROMSolver::Step(Vector &S, double &t, double &dt)
     add(S, dt/6, k, z);
     f->SetTime(t + dt/2);
 
-    RKStages.push_back(y);
-    RKTime.push_back(t + 0.5 * dt);
+    RKStages[0] = y;
+    RKTime[0] = t + 0.5 * dt;
 
     f->Mult(y, k); // k2
     add(S, dt/2, k, y);
     z.Add(dt/3, k);
 
-    RKStages.push_back(y);
-    RKTime.push_back(t + 0.5 * dt);
+    RKStages[1] = y;
+    RKTime[1] = t + 0.5 * dt;
 
     f->Mult(y, k); // k3
     add(S, dt, k, y);
     z.Add(dt/3, k);
     f->SetTime(t + dt);
 
-    RKStages.push_back(y);
-    RKTime.push_back(t + dt);
+    RKStages[2] = y;
+    RKTime[2] = t + dt;
 
     f->Mult(y, k); // k4
     add(z, dt/6, k, S);

--- a/rom/laghos_timeinteg.cpp
+++ b/rom/laghos_timeinteg.cpp
@@ -42,20 +42,20 @@ void HydroODESolver::Init(TimeDependentOperator &_f)
     }
 }
 
-void HydroODESolver::SetSampler(ROM_Sampler &_s)
+void HydroODESolver::SetSampler(ROM_Sampler &_f)
 {
     if (!rom)
     {
-        sampler = dynamic_cast<ROM_Sampler *>(s);
+        sampler = dynamic_cast<ROM_Sampler *>(f);
         MFEM_VERIFY(sampler, "HydroSolvers expect ROM_Sampler.");
     }
 }
 
-void HydroODESolver::SetSampler(ROM_Sampler &_s)
+void HydroODESolver::SetSamplerLast(ROM_Sampler &_f)
 {
     if (!rom)
     {
-        samplerLast = dynamic_cast<ROM_Sampler *>(s);
+        samplerLast = dynamic_cast<ROM_Sampler *>(f);
         MFEM_VERIFY(samplerLast, "HydroSolvers expect ROM_Sampler.");
     }
 }
@@ -96,8 +96,8 @@ void RK2AvgSolver::Step(Vector &S, double &t, double &dt)
     // -- 2.
     // S = S0 + 0.5 * dt * dS_dt;
     add(S0, 0.5 * dt, dS_dt, S);
-    if (sampler) sampler->SampleSolution(t, dt, *S);
-    if (samplerLast) samplerLast->SampleSolution(t, dt, *S);
+    if (sampler) sampler->SampleSolution(t, dt, S);
+    if (samplerLast) samplerLast->SampleSolution(t, dt, S);
     hydro_oper->ResetQuadratureData();
     hydro_oper->UpdateMesh(S);
     hydro_oper->SolveVelocity(S, dS_dt);

--- a/rom/laghos_timeinteg.cpp
+++ b/rom/laghos_timeinteg.cpp
@@ -42,24 +42,6 @@ void HydroODESolver::Init(TimeDependentOperator &_f)
     }
 }
 
-void HydroODESolver::SetSampler(ROM_Sampler *f)
-{
-    if (!rom)
-    {
-        sampler = f;
-        MFEM_VERIFY(sampler, "HydroSolvers expect ROM_Sampler.");
-    }
-}
-
-void HydroODESolver::SetSamplerLast(ROM_Sampler *f)
-{
-    if (!rom)
-    {
-        samplerLast = f;
-        MFEM_VERIFY(samplerLast, "HydroSolvers expect ROM_Sampler.");
-    }
-}
-
 void RK2AvgSolver::Step(Vector &S, double &t, double &dt)
 {
     if (rom)
@@ -100,12 +82,6 @@ void RK2AvgSolver::Step(Vector &S, double &t, double &dt)
 
     RKStages.push_back(S);
     RKTime.push_back(t + 0.5 * dt);
-    //if (samplerLast) samplerLast->SampleSolution(t + 0.5 * dt, dt, S);
-    //if (sampler)
-    //{
-    //    sampler->SampleSolution(t + 0.5 * dt, dt, S);
-    //    if (sampler->GetRank() == 0) std::cout << "1st RK2Avg stage sampled" << endl;
-    //}
     
     hydro_oper->ResetQuadratureData();
     hydro_oper->UpdateMesh(S);
@@ -144,13 +120,6 @@ void RK4ROMSolver::Step(Vector &S, double &t, double &dt)
 
     RKStages.push_back(y);
     RKTime.push_back(t + 0.5 * dt);
-    //RKTime.push_back(t + 0.4999 * dt); // Well-ordered snapshot time
-    //if (samplerLast) samplerLast->SampleSolution(t + 0.5 * dt, dt, y);
-    //if (sampler)
-    //{
-    //    sampler->SampleSolution(t + 0.5 * dt, dt, y);
-    //    if (sampler->GetRank() == 0) std::cout << "1st RK4 stage sampled" << endl;
-    //}
 
     f->Mult(y, k); // k2
     add(S, dt/2, k, y);
@@ -158,13 +127,6 @@ void RK4ROMSolver::Step(Vector &S, double &t, double &dt)
 
     RKStages.push_back(y);
     RKTime.push_back(t + 0.5 * dt);
-    //RKTime.push_back(t + 0.5001 * dt); // Well-ordered snapshot time
-    //if (samplerLast) samplerLast->SampleSolution(t + 0.5 * dt, dt, y);
-    //if (sampler)
-    //{
-    //    sampler->SampleSolution(t + 0.5 * dt, dt, y);
-    //    if (sampler->GetRank() == 0) std::cout << "2nd RK4 stage sampled" << endl;
-    //}
 
     f->Mult(y, k); // k3
     add(S, dt, k, y);
@@ -173,13 +135,6 @@ void RK4ROMSolver::Step(Vector &S, double &t, double &dt)
 
     RKStages.push_back(y);
     RKTime.push_back(t + dt);
-    //RKTime.push_back(t + 0.9999 * dt); // Well-ordered snapshot time
-    //if (samplerLast) samplerLast->SampleSolution(t + dt, dt, y);
-    //if (sampler)
-    //{
-    //    sampler->SampleSolution(t + dt, dt, y);
-    //    if (sampler->GetRank() == 0) std::cout << "3rd RK4 stage sampled" << endl;
-    //}
 
     f->Mult(y, k); // k4
     add(z, dt/6, k, S);

--- a/rom/laghos_timeinteg.cpp
+++ b/rom/laghos_timeinteg.cpp
@@ -51,6 +51,7 @@ void RK2AvgSolver::Step(Vector &S, double &t, double &dt)
     }
 
     RKStages.clear();
+    RKTime.clear();
     const int Vsize = hydro_oper->GetH1VSize();
     Vector V(Vsize), dS_dt(S.Size()), S0(S);
 

--- a/rom/laghos_timeinteg.cpp
+++ b/rom/laghos_timeinteg.cpp
@@ -82,7 +82,7 @@ void RK2AvgSolver::Step(Vector &S, double &t, double &dt)
 
     RKStages.push_back(S);
     RKTime.push_back(t + 0.5 * dt);
-    
+
     hydro_oper->ResetQuadratureData();
     hydro_oper->UpdateMesh(S);
     hydro_oper->SolveVelocity(S, dS_dt);

--- a/rom/laghos_timeinteg.cpp
+++ b/rom/laghos_timeinteg.cpp
@@ -90,8 +90,8 @@ void RK2AvgSolver::Step(Vector &S, double &t, double &dt)
     // -- 2.
     // S = S0 + 0.5 * dt * dS_dt;
     add(S0, 0.5 * dt, dS_dt, S);
-    if (sampler) sampler->SampleSolution(t, dt, S);
-    if (samplerLast) samplerLast->SampleSolution(t, dt, S);
+    if (sampler) sampler->SampleSolution(t + 0.5 * dt, dt, S);
+    if (samplerLast) samplerLast->SampleSolution(t + 0.5 * dt, dt, S);
     hydro_oper->ResetQuadratureData();
     hydro_oper->UpdateMesh(S);
     hydro_oper->SolveVelocity(S, dS_dt);

--- a/rom/laghos_timeinteg.cpp
+++ b/rom/laghos_timeinteg.cpp
@@ -42,6 +42,24 @@ void HydroODESolver::Init(TimeDependentOperator &_f)
     }
 }
 
+void HydroODESolver::SetSampler(ROM_Sampler &_s)
+{
+    if (!rom)
+    {
+        sampler = dynamic_cast<ROM_Sampler *>(s);
+        MFEM_VERIFY(sampler, "HydroSolvers expect ROM_Sampler.");
+    }
+}
+
+void HydroODESolver::SetSampler(ROM_Sampler &_s)
+{
+    if (!rom)
+    {
+        samplerLast = dynamic_cast<ROM_Sampler *>(s);
+        MFEM_VERIFY(samplerLast, "HydroSolvers expect ROM_Sampler.");
+    }
+}
+
 void RK2AvgSolver::Step(Vector &S, double &t, double &dt)
 {
     if (rom)
@@ -78,6 +96,8 @@ void RK2AvgSolver::Step(Vector &S, double &t, double &dt)
     // -- 2.
     // S = S0 + 0.5 * dt * dS_dt;
     add(S0, 0.5 * dt, dS_dt, S);
+    if (sampler) sampler->SampleSolution(t, dt, *S);
+    if (samplerLast) samplerLast->SampleSolution(t, dt, *S);
     hydro_oper->ResetQuadratureData();
     hydro_oper->UpdateMesh(S);
     hydro_oper->SolveVelocity(S, dS_dt);

--- a/rom/laghos_timeinteg.cpp
+++ b/rom/laghos_timeinteg.cpp
@@ -44,14 +44,20 @@ void HydroODESolver::Init(TimeDependentOperator &_f)
 
 void HydroODESolver::SetSampler(ROM_Sampler *f)
 {
-    sampler = f;
-    MFEM_VERIFY(sampler, "HydroSolvers expect ROM_Sampler.");
+    if (!rom)
+    {
+        sampler = f;
+        MFEM_VERIFY(sampler, "HydroSolvers expect ROM_Sampler.");
+    }
 }
 
 void HydroODESolver::SetSamplerLast(ROM_Sampler *f)
 {
-    samplerLast = f;
-    MFEM_VERIFY(samplerLast, "HydroSolvers expect ROM_Sampler.");
+    if (!rom)
+    {
+        samplerLast = f;
+        MFEM_VERIFY(samplerLast, "HydroSolvers expect ROM_Sampler.");
+    }
 }
 
 void RK2AvgSolver::Step(Vector &S, double &t, double &dt)

--- a/rom/laghos_timeinteg.cpp
+++ b/rom/laghos_timeinteg.cpp
@@ -143,7 +143,8 @@ void RK4ROMSolver::Step(Vector &S, double &t, double &dt)
     f->SetTime(t + dt/2);
 
     RKStages.push_back(y);
-    RKTime.push_back(t + 0.4999 * dt); // Well-ordered snapshot time
+    RKTime.push_back(t + 0.5 * dt);
+    //RKTime.push_back(t + 0.4999 * dt); // Well-ordered snapshot time
     //if (samplerLast) samplerLast->SampleSolution(t + 0.5 * dt, dt, y);
     //if (sampler)
     //{
@@ -156,7 +157,8 @@ void RK4ROMSolver::Step(Vector &S, double &t, double &dt)
     z.Add(dt/3, k);
 
     RKStages.push_back(y);
-    RKTime.push_back(t + 0.5001 * dt); // Well-ordered snapshot time
+    RKTime.push_back(t + 0.5 * dt);
+    //RKTime.push_back(t + 0.5001 * dt); // Well-ordered snapshot time
     //if (samplerLast) samplerLast->SampleSolution(t + 0.5 * dt, dt, y);
     //if (sampler)
     //{
@@ -170,7 +172,8 @@ void RK4ROMSolver::Step(Vector &S, double &t, double &dt)
     f->SetTime(t + dt);
 
     RKStages.push_back(y);
-    RKTime.push_back(t + 0.9999 * dt); // Well-ordered snapshot time
+    RKTime.push_back(t + dt);
+    //RKTime.push_back(t + 0.9999 * dt); // Well-ordered snapshot time
     //if (samplerLast) samplerLast->SampleSolution(t + dt, dt, y);
     //if (sampler)
     //{

--- a/rom/laghos_timeinteg.cpp
+++ b/rom/laghos_timeinteg.cpp
@@ -96,8 +96,12 @@ void RK2AvgSolver::Step(Vector &S, double &t, double &dt)
     // -- 2.
     // S = S0 + 0.5 * dt * dS_dt;
     add(S0, 0.5 * dt, dS_dt, S);
-    if (sampler) sampler->SampleSolution(t + 0.5 * dt, dt, S);
     if (samplerLast) samplerLast->SampleSolution(t + 0.5 * dt, dt, S);
+    if (sampler)
+    {
+        sampler->SampleSolution(t + 0.5 * dt, dt, S);
+        if (sampler->GetRank() == 0) std::cout << "1st RK2Avg stage sampled" << endl;
+    }
     hydro_oper->ResetQuadratureData();
     hydro_oper->UpdateMesh(S);
     hydro_oper->SolveVelocity(S, dS_dt);
@@ -131,21 +135,36 @@ void RK4ROMSolver::Step(Vector &S, double &t, double &dt)
     add(S, dt/6, k, z);
 
     f->SetTime(t + dt/2);
-    if (sampler) sampler->SampleSolution(t + 0.5 * dt, dt, y);
     if (samplerLast) samplerLast->SampleSolution(t + 0.5 * dt, dt, y);
+    if (sampler)
+    {
+        sampler->SampleSolution(t + 0.5 * dt, dt, y);
+        if (sampler->GetRank() == 0) std::cout << "1st RK4 stage sampled" << endl;
+    }
+
     f->Mult(y, k); // k2
     add(S, dt/2, k, y);
     z.Add(dt/3, k);
 
-    if (sampler) sampler->SampleSolution(t + 0.5 * dt, dt, y);
     if (samplerLast) samplerLast->SampleSolution(t + 0.5 * dt, dt, y);
+    if (sampler)
+    {
+        sampler->SampleSolution(t + 0.5 * dt, dt, y);
+        if (sampler->GetRank() == 0) std::cout << "2nd RK4 stage sampled" << endl;
+    }
+
     f->Mult(y, k); // k3
     add(S, dt, k, y);
     z.Add(dt/3, k);
 
     f->SetTime(t + dt);
-    if (sampler) sampler->SampleSolution(t + dt, dt, y);
     if (samplerLast) samplerLast->SampleSolution(t + dt, dt, y);
+    if (sampler)
+    {
+        sampler->SampleSolution(t + dt, dt, y);
+        if (sampler->GetRank() == 0) std::cout << "3rd RK4 stage sampled" << endl;
+    }
+
     f->Mult(y, k); // k4
     add(z, dt/6, k, S);
     t += dt;

--- a/rom/laghos_timeinteg.cpp
+++ b/rom/laghos_timeinteg.cpp
@@ -142,8 +142,8 @@ void RK4ROMSolver::Step(Vector &S, double &t, double &dt)
     add(S, dt/6, k, z);
     f->SetTime(t + dt/2);
 
-    RKStages.push_back(S);
-    RKTime.push_back(t + dt/2);
+    RKStages.push_back(y);
+    RKTime.push_back(t + 0.4999 * dt); // Well-ordered snapshot time
     //if (samplerLast) samplerLast->SampleSolution(t + 0.5 * dt, dt, y);
     //if (sampler)
     //{
@@ -155,8 +155,8 @@ void RK4ROMSolver::Step(Vector &S, double &t, double &dt)
     add(S, dt/2, k, y);
     z.Add(dt/3, k);
 
-    RKStages.push_back(S);
-    RKTime.push_back(t + dt/2);
+    RKStages.push_back(y);
+    RKTime.push_back(t + 0.5001 * dt); // Well-ordered snapshot time
     //if (samplerLast) samplerLast->SampleSolution(t + 0.5 * dt, dt, y);
     //if (sampler)
     //{
@@ -169,8 +169,8 @@ void RK4ROMSolver::Step(Vector &S, double &t, double &dt)
     z.Add(dt/3, k);
     f->SetTime(t + dt);
 
-    RKStages.push_back(S);
-    RKTime.push_back(t + dt);
+    RKStages.push_back(y);
+    RKTime.push_back(t + 0.9999 * dt); // Well-ordered snapshot time
     //if (samplerLast) samplerLast->SampleSolution(t + dt, dt, y);
     //if (sampler)
     //{

--- a/rom/laghos_timeinteg.cpp
+++ b/rom/laghos_timeinteg.cpp
@@ -44,20 +44,12 @@ void HydroODESolver::Init(TimeDependentOperator &_f)
 
 void HydroODESolver::SetSampler(ROM_Sampler &_f)
 {
-    if (!rom)
-    {
-        sampler = dynamic_cast<ROM_Sampler *>(f);
-        MFEM_VERIFY(sampler, "HydroSolvers expect ROM_Sampler.");
-    }
+    sampler = dynamic_cast<ROM_Sampler *>(f);
 }
 
 void HydroODESolver::SetSamplerLast(ROM_Sampler &_f)
 {
-    if (!rom)
-    {
-        samplerLast = dynamic_cast<ROM_Sampler *>(f);
-        MFEM_VERIFY(samplerLast, "HydroSolvers expect ROM_Sampler.");
-    }
+    samplerLast = dynamic_cast<ROM_Sampler *>(f);
 }
 
 void RK2AvgSolver::Step(Vector &S, double &t, double &dt)

--- a/rom/laghos_timeinteg.cpp
+++ b/rom/laghos_timeinteg.cpp
@@ -91,7 +91,6 @@ void RK2AvgSolver::Step(Vector &S, double &t, double &dt)
     // S = S0 + 0.5 * dt * dS_dt;
     add(S0, 0.5 * dt, dS_dt, S);
     if (sampler) sampler->SampleSolution(t, dt, S);
-    else std::cout << "No sample for intemediate RK stages" << endl;
     if (samplerLast) samplerLast->SampleSolution(t, dt, S);
     hydro_oper->ResetQuadratureData();
     hydro_oper->UpdateMesh(S);

--- a/rom/laghos_timeinteg.hpp
+++ b/rom/laghos_timeinteg.hpp
@@ -37,6 +37,8 @@ protected:
     LagrangianHydroOperator *hydro_oper;
     ROM_Sampler *sampler, *samplerLast;
     ROM_Operator *rom_oper;
+    std::vector<Vector> RKStages;
+    std::vector<double> RKTime;
 
 public:
     HydroODESolver(const bool romOnline=false) : hydro_oper(NULL), sampler(NULL), samplerLast(NULL), rom_oper(NULL), rom(romOnline) { }
@@ -51,6 +53,16 @@ public:
     void SetSampler(ROM_Sampler *f);
 
     void SetSamplerLast(ROM_Sampler *f);
+
+    std::vector<Vector> GetRKStages()
+    {
+        return RKStages;
+    }
+
+    std::vector<double> GetRKTime()
+    {
+        return RKTime;
+    }
 };
 
 class RK2AvgSolver : public HydroODESolver

--- a/rom/laghos_timeinteg.hpp
+++ b/rom/laghos_timeinteg.hpp
@@ -48,9 +48,9 @@ public:
         MFEM_ABORT("Time stepping is undefined.");
     }
 
-    void SetSampler(ROM_Sampler &_s);
+    void SetSampler(ROM_Sampler &_f);
 
-    void SetSamplerLast(ROM_Sampler &_s);
+    void SetSamplerLast(ROM_Sampler &_f);
 };
 
 class RK2AvgSolver : public HydroODESolver

--- a/rom/laghos_timeinteg.hpp
+++ b/rom/laghos_timeinteg.hpp
@@ -49,10 +49,6 @@ public:
         MFEM_ABORT("Time stepping is undefined.");
     }
 
-    void SetSampler(ROM_Sampler *f);
-
-    void SetSamplerLast(ROM_Sampler *f);
-
     std::vector<Vector> GetRKStages()
     {
         return RKStages;

--- a/rom/laghos_timeinteg.hpp
+++ b/rom/laghos_timeinteg.hpp
@@ -40,7 +40,14 @@ protected:
     std::vector<double> RKTime;
 
 public:
-    HydroODESolver(const bool romOnline=false) : hydro_oper(NULL), rom_oper(NULL), rom(romOnline) { }
+    HydroODESolver(const bool romOnline=false, const int RKStepNumSamples=0) : hydro_oper(NULL), rom_oper(NULL), rom(romOnline) 
+    { 
+        if (RKStepNumSamples > 0)
+        {
+            RKStages.resize(RKStepNumSamples);
+            RKTime.resize(RKStepNumSamples);
+        }
+    }
 
     virtual void Init(TimeDependentOperator &_f);
 
@@ -66,8 +73,8 @@ private:
     ParFiniteElementSpace *H1FESpace, *L2FESpace;
 
 public:
-    RK2AvgSolver(const bool romOnline=false, ParFiniteElementSpace *H1FESpace_=NULL, ParFiniteElementSpace *L2FESpace_=NULL) : HydroODESolver(romOnline),
-        H1FESpace(H1FESpace_), L2FESpace(L2FESpace_) { }
+    RK2AvgSolver(const bool romOnline=false, ParFiniteElementSpace *H1FESpace_=NULL, ParFiniteElementSpace *L2FESpace_=NULL, const int RKStepNumSamples=0) : 
+        HydroODESolver(romOnline, RKStepNumSamples), H1FESpace(H1FESpace_), L2FESpace(L2FESpace_) { }
 
     virtual void Step(Vector &S, double &t, double &dt);
 };
@@ -75,7 +82,7 @@ public:
 class RK4ROMSolver : public HydroODESolver
 {
 public:
-    RK4ROMSolver(const bool romOnline=false) : HydroODESolver(romOnline) { }
+    RK4ROMSolver(const bool romOnline=false, const int RKStepNumSamples=0) : HydroODESolver(romOnline, RKStepNumSamples) { }
 
     virtual void Step(Vector &S, double &t, double &dt);
 };

--- a/rom/laghos_timeinteg.hpp
+++ b/rom/laghos_timeinteg.hpp
@@ -19,6 +19,7 @@
 
 #include "mfem.hpp"
 
+class ROM_Sampler;
 class ROM_Operator;
 
 namespace mfem
@@ -34,10 +35,11 @@ class HydroODESolver : public ODESolver
 protected:
     const bool rom;
     LagrangianHydroOperator *hydro_oper;
+    ROM_Sampler *sampler, *samplerLast;
     ROM_Operator *rom_oper;
 
 public:
-    HydroODESolver(const bool romOnline=false) : hydro_oper(NULL), rom_oper(NULL), rom(romOnline) { }
+    HydroODESolver(const bool romOnline=false) : hydro_oper(NULL), sampler(NULL), rom_oper(NULL), rom(romOnline) { }
 
     virtual void Init(TimeDependentOperator &_f);
 
@@ -45,6 +47,10 @@ public:
     {
         MFEM_ABORT("Time stepping is undefined.");
     }
+
+    void SetSampler(ROM_Sampler &_s);
+
+    void SetSamplerLast(ROM_Sampler &_s);
 };
 
 class RK2AvgSolver : public HydroODESolver

--- a/rom/laghos_timeinteg.hpp
+++ b/rom/laghos_timeinteg.hpp
@@ -56,12 +56,12 @@ public:
         MFEM_ABORT("Time stepping is undefined.");
     }
 
-    std::vector<Vector> GetRKStages()
+    std::vector<Vector>& GetRKStages()
     {
         return RKStages;
     }
 
-    std::vector<double> GetRKTime()
+    std::vector<double>& GetRKTime()
     {
         return RKTime;
     }

--- a/rom/laghos_timeinteg.hpp
+++ b/rom/laghos_timeinteg.hpp
@@ -48,9 +48,9 @@ public:
         MFEM_ABORT("Time stepping is undefined.");
     }
 
-    void SetSampler(ROM_Sampler &_f);
+    void SetSampler(ROM_Sampler *f);
 
-    void SetSamplerLast(ROM_Sampler &_f);
+    void SetSamplerLast(ROM_Sampler *f);
 };
 
 class RK2AvgSolver : public HydroODESolver

--- a/rom/laghos_timeinteg.hpp
+++ b/rom/laghos_timeinteg.hpp
@@ -68,6 +68,8 @@ public:
 class RK4ROMSolver : public HydroODESolver
 {
 public:
+    RK4ROMSolver(const bool romOnline=false) : HydroODESolver(romOnline) { }
+
     virtual void Step(Vector &S, double &t, double &dt);
 };
 

--- a/rom/laghos_timeinteg.hpp
+++ b/rom/laghos_timeinteg.hpp
@@ -65,6 +65,12 @@ public:
     virtual void Step(Vector &S, double &t, double &dt);
 };
 
+class RK4ROMSolver : public HydroODESolver
+{
+public:
+    virtual void Step(Vector &S, double &t, double &dt);
+};
+
 } // namespace hydrodynamics
 
 } // namespace mfem

--- a/rom/laghos_timeinteg.hpp
+++ b/rom/laghos_timeinteg.hpp
@@ -35,13 +35,12 @@ class HydroODESolver : public ODESolver
 protected:
     const bool rom;
     LagrangianHydroOperator *hydro_oper;
-    ROM_Sampler *sampler, *samplerLast;
     ROM_Operator *rom_oper;
     std::vector<Vector> RKStages;
     std::vector<double> RKTime;
 
 public:
-    HydroODESolver(const bool romOnline=false) : hydro_oper(NULL), sampler(NULL), samplerLast(NULL), rom_oper(NULL), rom(romOnline) { }
+    HydroODESolver(const bool romOnline=false) : hydro_oper(NULL), rom_oper(NULL), rom(romOnline) { }
 
     virtual void Init(TimeDependentOperator &_f);
 

--- a/rom/laghos_timeinteg.hpp
+++ b/rom/laghos_timeinteg.hpp
@@ -39,7 +39,7 @@ protected:
     ROM_Operator *rom_oper;
 
 public:
-    HydroODESolver(const bool romOnline=false) : hydro_oper(NULL), sampler(NULL), rom_oper(NULL), rom(romOnline) { }
+    HydroODESolver(const bool romOnline=false) : hydro_oper(NULL), sampler(NULL), samplerLast(NULL), rom_oper(NULL), rom(romOnline) { }
 
     virtual void Init(TimeDependentOperator &_f);
 

--- a/rom/laghos_utils.cpp
+++ b/rom/laghos_utils.cpp
@@ -128,6 +128,7 @@ void BasisGeneratorFinalSummary(CAROM::BasisGenerator* bg, const double energyFr
         }
     }
 
+    if (!reached_cutoff) cutoff = sing_vals->dim();
     if (printout) cout << "Take first " << cutoff << " of " << sing_vals->dim() << " basis vectors" << endl;
 }
 

--- a/rom/laghos_utils.cpp
+++ b/rom/laghos_utils.cpp
@@ -355,6 +355,8 @@ void SetWindowParameters(Array2D<int> const& twparam, ROM_Options & romOptions)
     romOptions.dimE = min(romOptions.max_dimE, twparam(w,2));
     romOptions.dimFv = romOptions.SNS ? romOptions.dimV : min(romOptions.max_dimFv, twparam(w,3));
     romOptions.dimFe = romOptions.SNS ? romOptions.dimE : min(romOptions.max_dimFe, twparam(w,4));
+    if (romOptions.useXV) romOptions.dimX = romOptions.dimV;
+    if (romOptions.useVX) romOptions.dimV = romOptions.dimX;
 
     const int oss = (romOptions.SNS) ? 3 : 5;
     romOptions.sampX = twparam(w,oss);

--- a/rom/merge.cpp
+++ b/rom/merge.cpp
@@ -306,6 +306,8 @@ void GetParametricTimeWindows(const int nset, const bool SNS, const std::string&
         double overlapMidpoint = (windowLeft + windowRight) / 2;
         twep.Append(overlapMidpoint);
 
+        cout << windowLeft << " " << windowRight << endl;
+
         if (numSnap[0] == offsetCurrentWindow[0]+1)
         {
             for (int i = 1; i < nset*numVar; ++i)

--- a/rom/merge.cpp
+++ b/rom/merge.cpp
@@ -306,8 +306,6 @@ void GetParametricTimeWindows(const int nset, const bool SNS, const std::string&
         double overlapMidpoint = (windowLeft + windowRight) / 2;
         twep.Append(overlapMidpoint);
 
-        cout << windowLeft << " " << windowRight << endl;
-
         if (numSnap[0] == offsetCurrentWindow[0]+1)
         {
             for (int i = 1; i < nset*numVar; ++i)

--- a/rom/setup.sh
+++ b/rom/setup.sh
@@ -27,10 +27,10 @@ if [ ! -d "libROM" ]; then
 fi
 cd libROM
 git pull
-if [[ $1 == "Yes" ]]; then
+if [[ $1 == "YES" ]]; then
     DEBUG="-d"
 fi
-if [[ $2  == "Yes" ]]; then
+if [[ $2  == "YES" ]]; then
     UPDATE="-u"
 fi
 ./scripts/compile.sh -m $DEBUG $UPDATE

--- a/rom/tests/runRegressionTests.sh
+++ b/rom/tests/runRegressionTests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #SBATCH -N 1
-#SBATCH -t 0:30:00
+#SBATCH -t 1:00:00
 #SBATCH -p pdebug
 #SBATCH -o sbatch.log
 #SBATCH --open-mode truncate

--- a/rom/tests/sedov-blast/sedov-blast-space-time.sh
+++ b/rom/tests/sedov-blast/sedov-blast-space-time.sh
@@ -1,10 +1,8 @@
 NUM_PARALLEL_PROCESSORS=1
-testNames=(offline romhr)
+testNames=(offline-romhr)
 case $subTestNum in
   1)
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.02 -offline -writesol -romsvds -no-romsns -no-romgs -no-romoffset -romst gnat_lspg
-    ;;
-  2)
     $LAGHOS -m data/cube01_hex.mesh -pt 211 -tf 0.02 -online -romhrprep -rdimx 3 -rdimv 17 -rdime 7 -rdimfv 25 -rdimfe 12 -ntsamv 1 -ntsame 1 -sfacv 2 -sface 2 -no-romgs -no-romoffset -romst gnat_lspg
     $LAGHOS_SERIAL -m data/cube01_hex.mesh -pt 211 -tf 0.02 -online -romhr -rdimx 3 -rdimv 17 -rdime 7 -rdimfv 25 -rdimfe 12 -ntsamv 1 -ntsame 1 -sfacv 2 -sface 2 -no-romgs -no-romoffset -romst gnat_lspg -soldiff
     ;;

--- a/rom/tests/taylor-green/taylor-green-space-time.sh
+++ b/rom/tests/taylor-green/taylor-green-space-time.sh
@@ -1,11 +1,9 @@
 NUM_PARALLEL_PROCESSORS=1
-testNames=(offline romhr)
+testNames=(offline-romhr)
 case $subTestNum in
   1)
       $LAGHOS -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -pa -offline -writesol -romsvds -no-romgs -no-romoffset -no-romsns -romst gnat_lspg
+      $LAGHOS -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -online -romhrprep -rdimx 10 -rdimv 10 -rdime 10 -rdimfv 15 -rdimfe 15 -ntsamv 10 -ntsame 10 -sfacv 10 -sface 10 -soldiff -no-romgs -no-romoffset -no-romsns -romst gnat_lspg
+      $LAGHOS_SERIAL -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -online -romhr -rdimx 10 -rdimv 10 -rdime 10 -rdimfv 15 -rdimfe 15 -ntsamv 10 -ntsame 10 -sfacv 10 -sface 10 -soldiff -no-romgs -no-romoffset -no-romsns -romst gnat_lspg
       ;;
-  2)
-    $LAGHOS -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -online -romhrprep -rdimx 10 -rdimv 10 -rdime 10 -rdimfv 15 -rdimfe 15 -ntsamv 10 -ntsame 10 -sfacv 10 -sface 10 -soldiff -no-romgs -no-romoffset -no-romsns -romst gnat_lspg
-    $LAGHOS_SERIAL -p 0 -rs 1 -iv -cfl 0.5 -tf 0.07 -online -romhr -rdimx 10 -rdimv 10 -rdime 10 -rdimfv 15 -rdimfe 15 -ntsamv 10 -ntsame 10 -sfacv 10 -sface 10 -soldiff -no-romgs -no-romoffset -no-romsns -romst gnat_lspg
-    ;;
 esac

--- a/rom/tests/triple-point/triple-point-space-time.sh
+++ b/rom/tests/triple-point/triple-point-space-time.sh
@@ -1,10 +1,8 @@
 NUM_PARALLEL_PROCESSORS=1
-testNames=(offline romhr)
+testNames=(offline-romhr)
 case $subTestNum in
   1)
     $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.1 -cfl 0.05 -offline -writesol -romsvds -no-romgs -no-romoffset -no-romsns -romst gnat_lspg
-    ;;
-  2)
     $LAGHOS -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.1 -cfl 0.05 -online -romhrprep -rdimx 2 -rdimv 5 -rdime 4 -rdimfv 7 -rdimfe 6 -ntsamv 1 -ntsame 1 -sfacv 2 -sface 2 -soldiff -no-romgs -no-romoffset -no-romsns -romst gnat_lspg
     $LAGHOS_SERIAL -p 3 -m data/box01_hex.mesh -rs 1 -tf 0.1 -cfl 0.05 -online -romhr -rdimx 2 -rdimv 5 -rdime 4 -rdimfv 7 -rdimfe 6 -ntsamv 1 -ntsame 1 -sfacv 2 -sface 2 -soldiff -no-romgs -no-romoffset -no-romsns -romst gnat_lspg
     ;;


### PR DESCRIPTION
Implement the capability of sampling intermediate RK stages during offline stage. 

- Command line option `-sample-stages` controls the activation of the new capability.
- New member functions `GetRKStages` and `GetRKTime` are defined in the derived class `HydroODESolver` to enable the sampler access the RK stages and time stored in the time integrator.
- In order to enable the capability, `ode_solver` has to belong to a derived class of `HydroODESolver`, e.g. `RK2AvgSolver` and `RK4ROMSolver`. The new capability is now only compatible with RK2 average and RK4 schemes.