### PR TITLE
Follow up for PR 152

### DIFF
--- a/rom/laghos.cpp
+++ b/rom/laghos.cpp
@@ -335,6 +335,13 @@ int main(int argc, char *argv[])
     if (std::string(basename) != "") {
         outputPath += "/" + std::string(basename);
     }
+
+    std::string solution_outputPath = outputPath;
+    if (std::string(solution_basename) != "") {
+        solution_outputPath += "/" + std::string(solution_basename);
+    }
+    romOptions.solution_basename = &solution_outputPath;
+
     if (mpi.Root()) {
         const char path_delim = '/';
         std::string::size_type pos = 0;
@@ -345,7 +352,7 @@ int main(int argc, char *argv[])
         }
         while (pos != std::string::npos);
         mkdir((outputPath + "/ROMoffset").c_str(), 0777);
-        mkdir((outputPath + "/ROMsol").c_str(), 0777);
+        mkdir((solution_outputPath + "/ROMsol").c_str(), 0777);
     }
 
     MFEM_VERIFY(!(romOptions.useXV && romOptions.useVX), "");
@@ -368,12 +375,6 @@ int main(int argc, char *argv[])
     localmap["max"] = maxnorm;
 
     NormType normtype = localmap[normtype_char];
-
-    std::string solution_outputPath = outputPath;
-    if (std::string(solution_basename) != "") {
-        solution_outputPath += "/" + std::string(solution_basename);
-    }
-    romOptions.solution_basename = &solution_outputPath;
 
     CAROM::GreedyParameterPointSampler* parameterPointGreedySampler = NULL;
     bool rom_calc_rel_error = false;
@@ -631,7 +632,7 @@ int main(int argc, char *argv[])
     romOptions.offsetType = getOffsetStyle(offsetType);
     if (rom_online)
     {
-        std::string filename = outputPath + "/ROMsol/romS_1";
+        std::string filename = solution_outputPath + "/ROMsol/romS_1";
         std::ifstream infile_romS(filename.c_str());
         MFEM_VERIFY(!infile_romS.good(), "ROMsol files already exist.")
         VerifyOfflineParam(dim, dt, romOptions, numWindows, twfile, offlineParam_outputPath, false);
@@ -1253,7 +1254,7 @@ int main(int argc, char *argv[])
             // read ROM solution from a file.
             // TODO: it needs to be read from the format of HDF5 format
             // TODO: how about parallel version? introduce rank in filename
-            std::string filename = outputPath + "/ROMsol/romS_" + std::to_string(ti);
+            std::string filename = solution_outputPath + "/ROMsol/romS_" + std::to_string(ti);
             std::ifstream infile_romS(filename.c_str());
             if (infile_romS.good())
             {
@@ -1307,7 +1308,7 @@ int main(int argc, char *argv[])
             }
         } // time loop in "restore" phase
         ti--;
-        std::string filename = outputPath + "/ROMsol/romS_" + std::to_string(ti);
+        std::string filename = solution_outputPath + "/ROMsol/romS_" + std::to_string(ti);
         std::ifstream infile_romS(filename.c_str());
         if (myid == 0)
             cout << "Restoring " << ti << "-th solution" << endl;
@@ -1406,7 +1407,7 @@ int main(int argc, char *argv[])
                 // TODO: think about how to reuse "gfprint" option
                 if (!rom_build_database)
                 {
-                    std::string filename = outputPath + "/ROMsol/romS_" + std::to_string(ti);
+                    std::string filename = solution_outputPath + "/ROMsol/romS_" + std::to_string(ti);
                     std::ofstream outfile_romS(filename.c_str());
                     outfile_romS.precision(16);
                     if (romOptions.hyperreduce && romOptions.GramSchmidt)

--- a/rom/laghos_rom.cpp
+++ b/rom/laghos_rom.cpp
@@ -366,7 +366,7 @@ ROM_Basis::ROM_Basis(ROM_Options const& input, MPI_Comm comm_, MPI_Comm rom_com_
       use_sns(input.SNS),  offsetInit(input.useOffset),
       hyperreduce(input.hyperreduce), hyperreduce_prep(input.hyperreduce_prep),
       useGramSchmidt(input.GramSchmidt), lhoper(input.FOMoper),
-      RK2AvgFormulation(input.RK2AvgSolver), basename(*input.basename),
+      RK2AvgFormulation(input.RK2AvgSolver), basename(*input.basename), solution_basename(*input.solution_basename),
       mergeXV(input.mergeXV), useXV(input.useXV), useVX(input.useVX), Voffset(!input.useXV && !input.useVX && !input.mergeXV),
       energyFraction_X(input.energyFraction_X), use_qdeim(input.qdeim), basisIdentifier(input.basisIdentifier),
       spaceTimeMethod(input.spaceTimeMethod), spaceTime(input.spaceTimeMethod != no_space_time), VTos(input.VTos)
@@ -2796,7 +2796,7 @@ void ROM_Basis::SetSpaceTimeInitialGuessComponent(Vector& st, std::string const&
     char fileExtension[100];
     sprintf(fileExtension, ".%06d", rank);
 
-    std::string fullname = basename + "/ST_Sol_" + name + fileExtension;
+    std::string fullname = solution_basename + "/ST_Sol_" + name + fileExtension;
     std::ifstream ifs(fullname.c_str());
 
     const int tvsize = fespace->GetTrueVSize();

--- a/rom/laghos_rom.hpp
+++ b/rom/laghos_rom.hpp
@@ -117,6 +117,7 @@ struct ROM_Options
     ParFiniteElementSpace *L2FESpace = NULL; // FOM L2 FEM space
 
     std::string *basename = NULL;
+    std::string *solution_basename = NULL;
 
     std::string basisIdentifier = "";
     std::string greedyParam = "bef";
@@ -683,6 +684,7 @@ private:
     CAROM::Matrix* basisFe = 0;
 
     std::string basename = "run";
+    std::string solution_basename = "run";
 
     CAROM::Vector *fH1, *fL2;
 

--- a/rom/laghos_timeinteg.cpp
+++ b/rom/laghos_timeinteg.cpp
@@ -79,8 +79,11 @@ void RK2AvgSolver::Step(Vector &S, double &t, double &dt)
     // S = S0 + 0.5 * dt * dS_dt;
     add(S0, 0.5 * dt, dS_dt, S);
 
-    RKStages[0] = S;
-    RKTime[0] = t + 0.5 * dt;
+    if (numRKStages > 0)
+    {
+        RKStages[0] = S;
+        RKTime[0] = t + 0.5 * dt;
+    }
 
     hydro_oper->ResetQuadratureData();
     hydro_oper->UpdateMesh(S);
@@ -115,23 +118,32 @@ void RK4ROMSolver::Step(Vector &S, double &t, double &dt)
     add(S, dt/6, k, z);
     f->SetTime(t + dt/2);
 
-    RKStages[0] = y;
-    RKTime[0] = t + 0.5 * dt;
+    if (numRKStages > 0)
+    {
+        RKStages[0] = y;
+        RKTime[0] = t + 0.5 * dt;
+    }
 
     f->Mult(y, k); // k2
     add(S, dt/2, k, y);
     z.Add(dt/3, k);
 
-    RKStages[1] = y;
-    RKTime[1] = t + 0.5 * dt;
+    if (numRKStages > 0)
+    {
+        RKStages[1] = y;
+        RKTime[1] = t + 0.5 * dt;
+    }
 
     f->Mult(y, k); // k3
     add(S, dt, k, y);
     z.Add(dt/3, k);
     f->SetTime(t + dt);
 
-    RKStages[2] = y;
-    RKTime[2] = t + dt;
+    if (numRKStages > 0)
+    {
+        RKStages[2] = y;
+        RKTime[2] = t + dt;
+    }
 
     f->Mult(y, k); // k4
     add(z, dt/6, k, S);

--- a/rom/laghos_timeinteg.hpp
+++ b/rom/laghos_timeinteg.hpp
@@ -36,12 +36,13 @@ protected:
     const bool rom;
     LagrangianHydroOperator *hydro_oper;
     ROM_Operator *rom_oper;
+    const int numRKStages;
     std::vector<Vector> RKStages;
     std::vector<double> RKTime;
 
 public:
-    HydroODESolver(const bool romOnline=false, const int RKStepNumSamples=0) : hydro_oper(NULL), rom_oper(NULL), rom(romOnline) 
-    { 
+    HydroODESolver(const bool romOnline=false, const int RKStepNumSamples=0) : hydro_oper(NULL), rom_oper(NULL), rom(romOnline), numRKStages(RKStepNumSamples)
+    {
         if (RKStepNumSamples > 0)
         {
             RKStages.resize(RKStepNumSamples);
@@ -73,7 +74,7 @@ private:
     ParFiniteElementSpace *H1FESpace, *L2FESpace;
 
 public:
-    RK2AvgSolver(const bool romOnline=false, ParFiniteElementSpace *H1FESpace_=NULL, ParFiniteElementSpace *L2FESpace_=NULL, const int RKStepNumSamples=0) : 
+    RK2AvgSolver(const bool romOnline=false, ParFiniteElementSpace *H1FESpace_=NULL, ParFiniteElementSpace *L2FESpace_=NULL, const int RKStepNumSamples=0) :
         HydroODESolver(romOnline, RKStepNumSamples), H1FESpace(H1FESpace_), L2FESpace(L2FESpace_) { }
 
     virtual void Step(Vector &S, double &t, double &dt);

--- a/rom/tests/runRegressionTests.sh
+++ b/rom/tests/runRegressionTests.sh
@@ -539,6 +539,9 @@ do
 									[[ "$fileName" != "sVal"*".000000" ]]; then
 										continue 1
 									fi
+									if [[ "$fileName" == *"norms.000000" ]]; then
+										continue 1
+									fi
 								elif [[ $testtype == "romhr" ]]; then
 									if [[ "$fileName" != "ROMsol" ]]; then
 										continue 1


### PR DESCRIPTION
- Fix failing regression tests caused by last commits in PR 152. Only allocate memory, record RK stages and store in `sampler` if `-sample-stages` is used
- Add an option `-soldir` of solution subdirectory to allow multiple FOM run to save FOM solution under the same output directory simultaneously. This is used for parametric tests. 