### PR TITLE
Reformat with AStyle-3.1

### DIFF
--- a/laghos_solver.cpp
+++ b/laghos_solver.cpp
@@ -1230,12 +1230,12 @@ void QKernel(const int NE, const int NQ,
             MFEM_FOREACH_THREAD(qy,y,Q1D)
             {
                QUpdateBody<DIM>(NE, e, NQ, qx + qy * Q1D,
-               use_viscosity, use_vorticity, h0, h1order, cfl, infinity,
-               Jinv, stress, sgrad_v, eig_val_data, eig_vec_data,
-               compr_dir, Jpi, ph_dir, stressJiT,
-               d_gamma, d_weights, d_Jacobians, d_rho0DetJ0w,
-               d_e_quads, d_grad_v_ext, d_Jac0inv,
-               d_dt_est, d_stressJinvT);
+                                use_viscosity, use_vorticity, h0, h1order, cfl, infinity,
+                                Jinv, stress, sgrad_v, eig_val_data, eig_vec_data,
+                                compr_dir, Jpi, ph_dir, stressJiT,
+                                d_gamma, d_weights, d_Jacobians, d_rho0DetJ0w,
+                                d_e_quads, d_grad_v_ext, d_Jac0inv,
+                                d_dt_est, d_stressJinvT);
             }
          }
          MFEM_SYNC_THREAD;
@@ -1261,12 +1261,12 @@ void QKernel(const int NE, const int NQ,
                MFEM_FOREACH_THREAD(qz,z,Q1D)
                {
                   QUpdateBody<DIM>(NE, e, NQ, qx + Q1D * (qy + qz * Q1D),
-                  use_viscosity, use_vorticity, h0, h1order, cfl, infinity,
-                  Jinv, stress, sgrad_v, eig_val_data, eig_vec_data,
-                  compr_dir, Jpi, ph_dir, stressJiT,
-                  d_gamma, d_weights, d_Jacobians, d_rho0DetJ0w,
-                  d_e_quads, d_grad_v_ext, d_Jac0inv,
-                  d_dt_est, d_stressJinvT);
+                                   use_viscosity, use_vorticity, h0, h1order, cfl, infinity,
+                                   Jinv, stress, sgrad_v, eig_val_data, eig_vec_data,
+                                   compr_dir, Jpi, ph_dir, stressJiT,
+                                   d_gamma, d_weights, d_Jacobians, d_rho0DetJ0w,
+                                   d_e_quads, d_grad_v_ext, d_Jac0inv,
+                                   d_dt_est, d_stressJinvT);
                }
             }
          }


### PR DESCRIPTION
MFEM switched to AStyle-3.1 in https://github.com/mfem/mfem/pull/2506.

This PR applies the new formatting in Laghos.