### PR TITLE
Sample mesh VisIt visualization

### DIFF
--- a/rom/README.md
+++ b/rom/README.md
@@ -119,7 +119,7 @@ To see the building instruction of **Laghos**, please see README.md in Laghos di
 
 #### Gresho vortex problem
 
-The 2D Gresho vortex problem can be runned with `-p 4`.
+The 2D Gresho vortex problem can be run with `-p 4`.
 
 A sample run of the offline stage and the full order model is:
 ```sh
@@ -134,7 +134,7 @@ The corresponding run of the reduce order model is:
 
 #### Sedov blast problem
 
-The 3D Sedov blast wave problem can be runned with `-p 1`.
+The 3D Sedov blast wave problem can be run with `-p 1`.
 
 A sample run of the offline stage and the full order model is:
 ```sh
@@ -149,7 +149,7 @@ The corresponding run of the reduce order model is:
 
 #### Taylor-Green vortex problem
 
-The 3D Taylor-Green vortex problem can be runned with `-p 0`.
+The 3D Taylor-Green vortex problem can be run with `-p 0`.
 
 A sample run of the offline stage and the full order model is:
 ```sh
@@ -164,7 +164,7 @@ The corresponding run of the reduce order model is:
 
 #### Triple-point problem
 
-The 3D triple-point problem can be runned with `-p 3`.
+The 3D triple-point problem can be run with `-p 3`.
 
 A sample run of the offline stage and the full order model is:
 ```sh
@@ -179,7 +179,7 @@ The corresponding run of the reduce order model is:
 
 #### Parametric Sedov blast problem
 
-The 3D parametric Sedov blast wave problem can be runned with `-p 1` in the snapshot collection. The snapshot data is passed to `merge`. (Note the `-bef` and `-rpar` option.)
+The 3D parametric Sedov blast wave problem can be run with `-p 1` in the snapshot collection. The snapshot data is passed to `merge`. (Note the `-bef` and `-rpar` option.)
 
 A sample run of the offline stage is:
 ```sh

--- a/rom/laghos_rom.cpp
+++ b/rom/laghos_rom.cpp
@@ -1323,7 +1323,8 @@ void ROM_Basis::SetupHyperreduction(ParFiniteElementSpace *H1FESpace, ParFiniteE
     // This creates sample_pmesh, sp_H1_space, and sp_L2_space only on rank 0.
     CAROM::CreateSampleMesh(*pmesh, H1_space, *H1FESpace, *L2FESpace, *(H1FESpace->FEColl()),
                             *(L2FESpace->FEColl()), rom_com, sample_dofs_merged,
-                            num_sample_dofs_per_proc_merged, sample_pmesh, sprows, all_sprows, s2sp, st2sp, sp_H1_space, sp_L2_space);
+                            num_sample_dofs_per_proc_merged, sample_pmesh, sprows, all_sprows, s2sp, st2sp, sp_H1_space, sp_L2_space,
+                            basename + "/sampleElems_" + std::to_string(window));
 
     if (rank == 0)
     {
@@ -1331,17 +1332,6 @@ void ROM_Basis::SetupHyperreduction(ParFiniteElementSpace *H1FESpace, ParFiniteE
         //SetBdryAttrForVelocity(sample_pmesh);
         SetBdryAttrForVelocity_Cartesian(sample_pmesh);
         sample_pmesh->EnsureNodes();
-
-        const bool printSampleMesh = true;
-        if (printSampleMesh)
-        {
-            ostringstream mesh_name;
-            mesh_name << basename + "/smesh." << setfill('0') << setw(6) << rank;
-
-            ofstream mesh_ofs(mesh_name.str().c_str());
-            mesh_ofs.precision(8);
-            sample_pmesh->Print(mesh_ofs);
-        }
     }
 
     // Set s2sp_H1 and s2sp_L2 from s2sp


### PR DESCRIPTION
This PR is paired with libROM PR 81 https://github.com/LLNL/libROM/pull/81

The sample elements are visualized globally on the full-order mesh, for each window, in `run/sampleElems_{N}_000000` where N is the time window index. The field `Sample Elements` is 1 on sample elements, 0 elsewhere. It is tested in serial and parallel, for the Sedov test.

It may be more convenient to add each time window's sample mesh visualization to a database, where time window index corresponds to VisIt timestep, so that VisIt animations can be made, stepping through all the time windows. That could be done by passing the VisIt DC to `CreateSampleMesh` rather than the filename.

Note that VisIt may display a uniformly refined mesh, incorrectly, as in the plot below (mesh has 8^3 elements, but VisIt shows 16^3).

<img width="614" alt="sampleMesh" src="https://user-images.githubusercontent.com/12700975/140166591-41f5cc11-cfa7-492b-8f62-e5ec05843913.png">
