### PR TITLE
Fix hypre link & build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,10 @@ Other computational motives in Laghos include the following:
 Laghos has the following external dependencies:
 
 - *hypre*, used for parallel linear algebra, we recommend version 2.11.2<br>
-   https://computation.llnl.gov/casc/hypre/software.html
+  https://github.com/hypre-space/hypre/releases/tag/v2.11.2 
 
--  METIS, used for parallel domain decomposition (optional), we recommend [version 4.0.3](https://github.com/mfem/tpls/blob/gh-pages/metis-4.0.3.tar.gz) <br>
-   https://github.com/mfem/tpls
+- METIS, used for parallel domain decomposition (optional), we recommend [version 4.0.3](https://github.com/mfem/tpls/blob/gh-pages/metis-4.0.3.tar.gz) <br>
+  https://github.com/mfem/tpls
 
 - MFEM, used for (high-order) finite element discretization, its GitHub master branch <br>
   https://github.com/mfem/mfem
@@ -140,16 +140,17 @@ To build the miniapp, first download *hypre* and METIS from the links above
 and put everything on the same level as the `Laghos` directory:
 ```sh
 ~> ls
-Laghos/  hypre-2.11.2.tar.gz  metis-4.0.3.tar.gz
+Laghos/  v2.11.2.tar.gz  metis-4.0.3.tar.gz
 ```
 
 Build *hypre*:
 ```sh
-~> tar -zxvf hypre-2.11.2.tar.gz
+~> tar -zxvf v2.11.2.tar.gz
 ~> cd hypre-2.11.2/src/
 ~/hypre-2.11.2/src> ./configure --disable-fortran
 ~/hypre-2.11.2/src> make -j
 ~/hypre-2.11.2/src> cd ../..
+~> ln -s hypre-2.11.2 hypre
 ```
 For large runs (problem size above 2 billion unknowns), add the
 `--enable-bigint` option to the above `configure` line.

--- a/makefile
+++ b/makefile
@@ -248,13 +248,13 @@ tests:
 
 # Setup: download & install third party libraries: HYPRE, METIS & MFEM
 
-HYPRE_URL = https://computation.llnl.gov/projects/hypre-scalable-linear-solvers-multigrid-methods
+HYPRE_URL = https://github.com/hypre-space/hypre/archive/refs/tags
 HYPRE_VER = 2.11.2
 HYPRE_DIR = hypre
 hypre:
 	@(if [[ ! -e ../$(HYPRE_DIR) ]]; then cd ..; \
-		wget -nc $(HYPRE_URL)/download/hypre-$(HYPRE_VER).tar.gz &&\
-		tar xzvf hypre-$(HYPRE_VER).tar.gz &&\
+		wget -nc $(HYPRE_URL)/v$(HYPRE_VER).tar.gz &&\
+		tar xzvf v$(HYPRE_VER).tar.gz &&\
 		ln -s hypre-$(HYPRE_VER) $(HYPRE_DIR) &&\
 		cd $(HYPRE_DIR)/src &&\
 		./configure --disable-fortran --without-fei CC=mpicc CXX=mpic++ &&\


### PR DESCRIPTION
Fixes the download link for `hypre` and updates the build instructions. 