### PR TITLE
Fix ROM regression tests

### DIFF
--- a/rom/.gitignore
+++ b/rom/.gitignore
@@ -1,0 +1,19 @@
+# Do not track objects or archives
+*.o
+*.orig
+run
+
+# Do not track backup files
+*~
+
+# Do not track log files
+*.log
+
+# Do not track executables
+laghos
+merge
+tests/basisComparator
+tests/checkError
+tests/computeSpeedup
+tests/fileComparator
+tests/solutionComparator

--- a/rom/.gitignore
+++ b/rom/.gitignore
@@ -17,3 +17,6 @@ tests/checkError
 tests/computeSpeedup
 tests/fileComparator
 tests/solutionComparator
+
+# Do not track dependencies
+dependencies

--- a/rom/laghos_rom.cpp
+++ b/rom/laghos_rom.cpp
@@ -363,11 +363,11 @@ CAROM::Matrix* ReadTemporalBasisROM(const int rank, const std::string filename, 
     // In libROM, a Matrix is always distributed row-wise. In this case, the global matrix is on each process.
     if (dim == -1)
     {
-        basis = (CAROM::Matrix*) reader.getTemporalBasis(0.0);
+        basis = (CAROM::Matrix*) reader.getTemporalBasis();
     }
     else
     {
-        basis = (CAROM::Matrix*) reader.getTemporalBasis(0.0, dim);
+        basis = (CAROM::Matrix*) reader.getTemporalBasis(dim);
     }
     temporalSize = basis->numRows();
 

--- a/rom/makefile
+++ b/rom/makefile
@@ -170,7 +170,7 @@ $(CONFIG_MK) $(MFEM_LIB_FILE):
 regtest: tests/fileComparator.cpp tests/basisComparator.cpp tests/solutionComparator.cpp tests/checkError.cpp tests/computeSpeedup.cpp
 	$(CXX) $(CXXFLAGS) -o tests/fileComparator tests/fileComparator.cpp
 	$(CXX) $(CXXFLAGS) -I$(LIBS_DIR)/libROM/lib -o tests/basisComparator tests/basisComparator.cpp -Wl,-rpath,$(LIBS_DIR)/libROM/build/lib -L$(LIBS_DIR)/libROM/build/lib -lROM
-	$(CXX) $(CXXFLAGS) $(MFEM_INCFLAGS) -o tests/solutionComparator tests/solutionComparator.cpp $(LIBS)
+	$(CXX) $(CXXFLAGS) $(MFEM_INCFLAGS) -L$(LIBS_DIR)/libROM/build/lib -o tests/solutionComparator tests/solutionComparator.cpp -Wl,-rpath,$(LIBS_DIR)/libROM/build/lib -L$(LIBS_DIR)/libROM/build/lib -lROM $(LIBS) -Wl,-rpath,${LIBS_DIR}/libROM/dependencies/parmetis-4.0.3/build/lib/libparmetis -L${LIBS_DIR}/libROM/dependencies/parmetis-4.0.3/build/lib/libparmetis -lparmetis -Wl,-rpath,${LIBS_DIR}/libROM/dependencies/parmetis-4.0.3/build/lib/libmetis -L${LIBS_DIR}/libROM/dependencies/parmetis-4.0.3/build/lib/libmetis -lmetis
 	$(CXX) $(CXXFLAGS) -o tests/checkError tests/checkError.cpp
 	$(CXX) $(CXXFLAGS) -o tests/computeSpeedup tests/computeSpeedup.cpp
 

--- a/rom/tests/REGRESSIONTEST.md
+++ b/rom/tests/REGRESSIONTEST.md
@@ -73,8 +73,8 @@ Only FOM solutions, ROM relative errors, and speed up are checked.
 
 ./runRegressionTests.sh -x -> Run all tests, but use the old regression test commands for the baseline and the new regression test commands for the user branch. This is useful if you would like to change the command-line for certain tests, but expect the same output. This can not be used with absolute tests.
 
-./runRegressionTests.sh -i "sedov_blast gresho_vortices" -> Run sedov_blast and gresho_vortices.
+./runRegressionTests.sh -i "sedov-blast gresho-vortices" -> Run sedov-blast and gresho-vortices.
 
 ./runRegressionTests.sh -e "taylor-green" -> Run all tests except taylor-green.
 
-./runRegressionTests.sh -i "sedov_blast" -e "taylor-green" -> Error. -i and -e can not be used simultaneously.
+./runRegressionTests.sh -i "sedov-blast" -e "taylor-green" -> Error. -i and -e can not be used simultaneously.


### PR DESCRIPTION
This PR depends on libROM PR 290, to fix the space-time regression tests.