### PR TITLE
Basic Caliper support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Other computational motives in Laghos include the following:
 - Domain-decomposed MPI parallelism.
 - Optional in-situ visualization with [GLVis](http:/glvis.org) and data output
   for visualization and data analysis with [VisIt](http://visit.llnl.gov).
+- Optional performance analysis with [Caliper](http://github.com/LLNL/caliper).
 
 ## Code Structure
 
@@ -187,6 +188,28 @@ See the [MFEM building page](http://mfem.org/building/) for additional details.
 The easiest way to visualize Laghos results is to have GLVis running in a
 separate terminal. Then the `-vis` option in Laghos will stream results directly
 to the GLVis socket.
+
+(Optional) Build Caliper
+1. Clone and build Adiak:
+```sh
+~> git clone --recursive https://github.com/LLNL/Adiak.git
+~> cd Adiak
+~/Adiak> mkdir build && cd build
+~/Adiak> cmake -DBUILD_SHARED_LIBS=On -DENABLE_MPI=On \
+               -DCMAKE_INSTALL_PREFIX=../../adiak ..
+~/Adiak> make && make install
+~/Adiak> cd ../..
+```
+2. Clone and build Caliper:
+```sh
+~> git clone https://github.com/LLNL/Caliper.git
+~> cd Caliper
+~/Caliper> mkdir build && cd build
+~/Caliper> cmake -DWITH_MPI=True -DWITH_ADIAK=True -Dadiak_ROOT=../../adiak/ \
+                 -DCMAKE_INSTALL_PREFIX=../../caliper ..
+~/Caliper> make && make install
+~/Caliper> cd ../..
+```
 
 Build Laghos
 ```sh

--- a/makefile
+++ b/makefile
@@ -72,6 +72,30 @@ ifeq ($(wildcard $(CONFIG_MK)),)
 endif
 TEST_MK = $(MFEM_TEST_MK)
 
+# Caliper install directory
+CALIPER_DIR ?= ../caliper
+ifeq ($(wildcard $(CALIPER_DIR)),)
+   CALIPER_INCLUDE :=
+   CALIPER_LIBS :=
+   CALIPER_FLAGS :=
+else
+   CALIPER_INCLUDE := -I $(CALIPER_DIR)/include
+   CALIPER_LIBS := -L $(CALIPER_DIR)/lib64 -lcaliper
+   CALIPER_FLAGS := -DUSE_CALIPER
+endif
+
+# Only configure Adiak if Caliper is enabled
+ifneq ($(CALIPER_FLAGS),)
+  ADIAK_DIR ?= ../adiak
+  ifeq ($(wildcard $(ADIAK_DIR)),)
+     ADIAK_INCLUDE :=
+     ADIAK_LIBS :=
+  else
+     ADIAK_INCLUDE := -I $(ADIAK_DIR)/include
+     ADIAK_LIBS := -L $(ADIAK_DIR)/lib -ladiak
+  endif
+endif
+
 # Use the compiler used by MFEM. Get the compiler and the options for compiling
 # and linking from MFEM's config.mk. (Skip this if the target does not require
 # building.)
@@ -88,13 +112,13 @@ endif
 
 CXX = $(MFEM_CXX)
 CPPFLAGS = $(MFEM_CPPFLAGS)
-CXXFLAGS = $(MFEM_CXXFLAGS)
+CXXFLAGS = $(MFEM_CXXFLAGS) $(CALIPER_INCLUDE) $(CALIPER_FLAGS) $(ADIAK_INCLUDE)
 LAGHOS_FLAGS = $(CPPFLAGS) $(CXXFLAGS) $(MFEM_INCFLAGS)
 # Extra include dir, needed for now to include headers like "general/forall.hpp"
 EXTRA_INC_DIR = $(or $(wildcard $(MFEM_DIR)/include/mfem),$(MFEM_DIR))
 CCC = $(strip $(CXX) $(LAGHOS_FLAGS) $(if $(EXTRA_INC_DIR),-I$(EXTRA_INC_DIR)))
 
-LAGHOS_LIBS = $(MFEM_LIBS) $(MFEM_EXT_LIBS)
+LAGHOS_LIBS = $(MFEM_LIBS) $(MFEM_EXT_LIBS) $(CALIPER_LIBS) $(ADIAK_LIBS)
 LIBS = $(strip $(LAGHOS_LIBS) $(LDFLAGS))
 
 SOURCE_FILES = $(sort $(wildcard *.cpp))


### PR DESCRIPTION
This PR adds Caliper and Adiak as optional dependencies and provides basic instrumentation of the time step loop. It does not attempt to replace the internal timers used for FOM calculations. If there is interest, additional sections of the code including the FOM calculation could be instrumented and refactored to use Caliper.