### PR TITLE
Fix macro to enable caliper

### DIFF
--- a/laghos_solver.cpp
+++ b/laghos_solver.cpp
@@ -19,7 +19,7 @@
 #include "linalg/kernels.hpp"
 #include <unordered_map>
 
-#ifdef USE_CALIPER
+#ifdef LAGHOS_USE_CALIPER
 #include <caliper/cali.h>
 #include <adiak.hpp>
 #define LAGHOS_CALI_MARK_BEGIN(x)  CALI_MARK_BEGIN(x)
@@ -776,7 +776,7 @@ void LagrangianHydroOperator::PrintTimingData(bool IamRoot, int steps,
            << "| " << setw(7) << FOM
            << "| " << setw(5) << T[4]
            << "| " << endl;
-#ifdef USE_CALIPER
+#ifdef LAGHOS_USE_CALIPER
       adiak::value("zones", GNZones);
       adiak::value("h1_dofs", H1GTVSize);
       adiak::value("l2_dofs", L2GTVSize);


### PR DESCRIPTION
The Laghos PR https://github.com/CEED/Laghos/pull/205/changes#diff-beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0 changed the macro used to enable caliper in laghos from `USE_CALIPER` to `LAGHOS_USE_CALIPER`. This PR fixes the usage of that macro in laghos_solver.cpp