### PR TITLE
Warm-up device pool allocation

### DIFF
--- a/laghos.cpp
+++ b/laghos.cpp
@@ -327,8 +327,8 @@ int main(int argc, char *argv[])
 #ifdef LAGHOS_USE_DEVICE_UMPIRE
    // Warm up the device pool on the configured GPU to avoid first-use latency.
    auto allocator = rm.getAllocator(allocator_name);
-   void *tmp = allocator.allocate(umpire_dev_block_size);
-   allocator.deallocate(tmp);
+   void *tmp_device_ptr = allocator.allocate(umpire_dev_block_size);
+   allocator.deallocate(tmp_device_ptr);
 #endif
 
    // Prepare the missing kernels.

--- a/laghos.cpp
+++ b/laghos.cpp
@@ -324,13 +324,13 @@ int main(int argc, char *argv[])
    if (Mpi::Root()) { backend.Print(); }
    backend.SetGPUAwareMPI(gpu_aware_mpi);
 
-   #ifdef LAGHOS_USE_DEVICE_UMPIRE
-      // Warm up the device pool on the configured GPU to avoid first-use latency.
-      auto allocator = rm.getAllocator(allocator_name);
-      void *tmp = allocator.allocate(umpire_dev_block_size);
-     allocator.deallocate(tmp);
-   #endif
-  
+#ifdef LAGHOS_USE_DEVICE_UMPIRE
+   // Warm up the device pool on the configured GPU to avoid first-use latency.
+   auto allocator = rm.getAllocator(allocator_name);
+   void *tmp = allocator.allocate(umpire_dev_block_size);
+   allocator.deallocate(tmp);
+#endif
+
    // Prepare the missing kernels.
    if (myid == 0) { KernelReporter::Enable(); }
    using TENS = QuadratureInterpolator::TensorEvalKernels;

--- a/laghos.cpp
+++ b/laghos.cpp
@@ -324,6 +324,13 @@ int main(int argc, char *argv[])
    if (Mpi::Root()) { backend.Print(); }
    backend.SetGPUAwareMPI(gpu_aware_mpi);
 
+   #ifdef LAGHOS_USE_DEVICE_UMPIRE
+      // Warm up the device pool on the configured GPU to avoid first-use latency.
+      auto allocator = rm.getAllocator(allocator_name);
+      void *tmp = allocator.allocate(umpire_dev_block_size);
+     allocator.deallocate(tmp);
+   #endif
+  
    // Prepare the missing kernels.
    if (myid == 0) { KernelReporter::Enable(); }
    using TENS = QuadratureInterpolator::TensorEvalKernels;


### PR DESCRIPTION
This PR adds a small "warm-up" allocation to the umpire device pool ahead of the main loop. This avoids the pool allocation call inside the timestepping code.